### PR TITLE
refactor: move `src/lib.rs` into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,10 +437,8 @@ version = "0.1.0"
 dependencies = [
  "async-h1",
  "async-std",
- "drawbridge-auth",
  "drawbridge-http",
- "drawbridge-tags",
- "drawbridge-tree",
+ "drawbridge-name",
 ]
 
 [[package]]
@@ -467,6 +465,15 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "drawbridge-name"
+version = "0.1.0"
+dependencies = [
+ "drawbridge-http",
+ "drawbridge-tags",
+ "drawbridge-tree",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -476,7 +476,7 @@ dependencies = [
  "async-std",
  "drawbridge-hash",
  "drawbridge-http",
- "semver 1.0.6",
+ "semver 1.0.7",
  "serde",
  "serde_json",
 ]
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -934,7 +934,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]
@@ -1187,9 +1187,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,17 @@ authors = ["Profian Inc"]
 edition = "2021"
 
 [workspace]
+members = [
+    "crates/auth",
+    "crates/hash",
+    "crates/tags",
+    "crates/tree",
+]
 
 [dependencies]
 # Internal dependencies
-drawbridge-auth = { path = "./crates/auth" }
 drawbridge-http = { path = "./crates/http" }
-drawbridge-tags = { path = "./crates/tags" }
-drawbridge-tree = { path = "./crates/tree" }
+drawbridge-name = { path = "./crates/name" }
 
 # External dependencies
 async-h1 = "2.3.3"

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Profian Inc"]
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-trait = "0.1.52"
 http-types = "2.12.0"

--- a/crates/name/Cargo.toml
+++ b/crates/name/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "drawbridge-name"
+version = "0.1.0"
+authors = ["Profian Inc"]
+edition = "2021"
+
+[dependencies]
+# Internal dependencies
+drawbridge-http = { path = "../http" }
+drawbridge-tags = { path = "../tags" }
+drawbridge-tree = { path = "../tree" }

--- a/crates/name/src/lib.rs
+++ b/crates/name/src/lib.rs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications, clippy::all)]
+#![forbid(unsafe_code)]
+
 use std::str::FromStr;
 
 use drawbridge_http::http::{self, Error, Request, Response, StatusCode};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use drawbridge::Service;
 use drawbridge_http::http::Result;
 use drawbridge_http::{Handler, IntoResponse};
+use drawbridge_name::Service;
 
 use async_std::net::TcpListener;
 use async_std::prelude::*;


### PR DESCRIPTION
Reorganize the crates for better separation of concerns and ability to have one crate (core) with functionality shared between components (e.g. namespacing)