### PR TITLE
refactor: add the drawbridge-type crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,14 @@ name = "drawbridge-auth"
 version = "0.1.0"
 
 [[package]]
+name = "drawbridge-byte"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "drawbridge-hash"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drawbridge-jose"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "drawbridge-byte",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "drawbridge-name"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
+name = "axum"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f346c92c1e9a71d14fe4aaf7c2a5d9932cc4e5e48d8fb6641524416eb79ddd"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "hyper",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbcda393bef9c87572779cb8ef916f12d77750b27535dd6819fa86591627a51"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +327,12 @@ name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -519,6 +570,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "drawbridge-type"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "base64",
+ "drawbridge-byte",
+ "headers",
+ "http",
+ "mime",
+ "serde",
+ "serde_json",
+ "sha2 0.10.2",
+ "tokio",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +599,12 @@ checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -577,6 +650,30 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -634,6 +731,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +785,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.6"
+source = "git+https://github.com/npmccallum/http?rev=0f4438e7f5107d8b06142894d2d9cd5186b721ab#0f4438e7f5107d8b06142894d2d9cd5186b721ab"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +838,35 @@ name = "httparse"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "idna"
@@ -769,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +963,38 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1083,6 +1299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1542,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1749,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/tags",
     "crates/tree",
     "crates/byte",
+    "crates/jose",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/hash",
     "crates/tags",
     "crates/tree",
+    "crates/byte",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/tree",
     "crates/byte",
     "crates/jose",
+    "crates/type",
 ]
 
 [dependencies]
@@ -22,3 +23,6 @@ drawbridge-name = { path = "./crates/name" }
 # External dependencies
 async-h1 = "2.3.3"
 async-std = "1.11.0"
+
+[patch.crates-io]
+http = { git = "https://github.com/npmccallum/http", rev = "0f4438e7f5107d8b06142894d2d9cd5186b721ab" }

--- a/crates/byte/Cargo.toml
+++ b/crates/byte/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "drawbridge-byte"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+base64 = "0.13.0"
+serde = { version = "1.0.136", features = ["derive"] }

--- a/crates/byte/src/lib.rs
+++ b/crates/byte/src/lib.rs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
+use serde::{de::Error as _, Deserialize, Serialize};
+
+pub trait Config {
+    const CONFIG: base64::Config;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Standard(());
+
+impl Config for Standard {
+    const CONFIG: base64::Config = base64::STANDARD;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UrlSafeNoPad(());
+
+impl Config for UrlSafeNoPad {
+    const CONFIG: base64::Config = base64::URL_SAFE_NO_PAD;
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bytes<T = Vec<u8>, C = Standard>(T, PhantomData<C>);
+
+impl<T, C> Bytes<T, C> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T, C> From<T> for Bytes<T, C> {
+    fn from(value: T) -> Self {
+        Self(value, PhantomData)
+    }
+}
+
+impl<T, C> Deref for Bytes<T, C> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, C> DerefMut for Bytes<T, C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: AsRef<[u8]>, C: Config> std::fmt::Display for Bytes<T, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&base64::encode_config(self.0.as_ref(), C::CONFIG))
+    }
+}
+
+impl<T: From<Vec<u8>>, C: Config> FromStr for Bytes<T, C> {
+    type Err = base64::DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        base64::decode_config(s, C::CONFIG).map(|x| Self(x.into(), PhantomData))
+    }
+}
+
+impl<T: AsRef<[u8]>, C: Config> Serialize for Bytes<T, C> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            base64::encode_config(self.0.as_ref(), C::CONFIG).serialize(serializer)
+        } else {
+            serializer.serialize_bytes(self.0.as_ref())
+        }
+    }
+}
+
+impl<'de, T: From<Vec<u8>>, C: Config> Deserialize<'de> for Bytes<T, C> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let b64 = String::deserialize(deserializer)?;
+            let buf = base64::decode_config(&b64, C::CONFIG)
+                .map_err(|_| D::Error::custom("invalid base64"))?;
+            Ok(Self(buf.into(), PhantomData))
+        } else {
+            Ok(Self(Vec::deserialize(deserializer)?.into(), PhantomData))
+        }
+    }
+}

--- a/crates/jose/Cargo.toml
+++ b/crates/jose/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "drawbridge-jose"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+drawbridge-byte = { path = "../byte" }
+base64 = "0.13.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"

--- a/crates/jose/src/b64.rs
+++ b/crates/jose/src/b64.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::{Deref, DerefMut};
+
+use drawbridge_byte::UrlSafeNoPad;
+
+use serde::de::DeserializeOwned;
+use serde::{ser::Error as _, Deserialize, Serialize};
+
+pub type Bytes<T = Vec<u8>> = drawbridge_byte::Bytes<T, UrlSafeNoPad>;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Json<T>(pub T);
+
+impl<T> From<T> for Json<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Deref for Json<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Json<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Serialize> Serialize for Json<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let buf = serde_json::to_vec(self).map_err(|_| S::Error::custom("encoding error"))?;
+        Bytes::from(buf).serialize(serializer)
+    }
+}
+
+impl<'de, T: DeserializeOwned> Deserialize<'de> for Json<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let buf = Bytes::<Vec<u8>>::deserialize(deserializer)?;
+        let val = serde_json::from_slice(&buf).unwrap();
+        Ok(Self(val))
+    }
+}

--- a/crates/jose/src/jws.rs
+++ b/crates/jose/src/jws.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::b64::{Bytes, Json};
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Jws<T = Bytes, P = BTreeMap<String, Value>, H = P>
+where
+    Json<P>: for<'a> Deserialize<'a>,
+{
+    General(General<T, P, H>),
+    Flattened(Flattened<T, P, H>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct General<T = Bytes, P = BTreeMap<String, Value>, H = P>
+where
+    Json<P>: for<'a> Deserialize<'a>,
+{
+    payload: T,
+    signatures: Vec<Signature<P, H>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Flattened<T = Bytes, P = BTreeMap<String, Value>, H = P>
+where
+    Json<P>: for<'a> Deserialize<'a>,
+{
+    payload: T,
+
+    #[serde(flatten)]
+    signature: Signature<P, H>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Signature<P = BTreeMap<String, Value>, H = P>
+where
+    Json<P>: for<'a> Deserialize<'a>,
+{
+    protected: Option<Json<P>>,
+    header: Option<H>,
+    signature: Bytes,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct Header {
+        kid: String,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct Protected {
+        alg: String,
+    }
+
+    // Example from RFC 7515 A.6.4
+    #[test]
+    fn general() {
+        let payload = "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+        let signature0 = "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw";
+        let signature1 = "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q";
+
+        let raw = json!({
+            "payload": payload,
+            "signatures": [
+                {
+                    "protected":"eyJhbGciOiJSUzI1NiJ9",
+                    "header": { "kid": "2010-12-29" },
+                    "signature": signature0,
+                },
+                {
+                    "protected":"eyJhbGciOiJFUzI1NiJ9",
+                    "header": { "kid":"e9bc097a-ce51-4036-9562-d2ade882db0d" },
+                    "signature": signature1,
+                }
+            ]
+        });
+
+        let sig0 = Signature {
+            header: Some(Header {
+                kid: "2010-12-29".to_string(),
+            }),
+            protected: Some(Json(Protected {
+                alg: "RS256".to_string(),
+            })),
+            signature: signature0.parse().unwrap(),
+        };
+
+        let sig1 = Signature {
+            header: Some(Header {
+                kid: "e9bc097a-ce51-4036-9562-d2ade882db0d".to_string(),
+            }),
+            protected: Some(Json(Protected {
+                alg: "ES256".to_string(),
+            })),
+            signature: signature1.parse().unwrap(),
+        };
+
+        let exp = Jws::<Bytes, Protected, Header>::General(General {
+            payload: payload.parse().unwrap(),
+            signatures: vec![sig0, sig1],
+        });
+
+        assert_eq!(exp, serde_json::from_value(raw).unwrap());
+    }
+
+    // Example from RFC 7515 A.7
+    #[test]
+    fn flattened() {
+        let payload = "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+        let signature = "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q";
+
+        let raw = json!({
+            "payload": payload,
+            "protected": "eyJhbGciOiJFUzI1NiJ9",
+            "header": { "kid": "e9bc097a-ce51-4036-9562-d2ade882db0d" },
+            "signature": signature,
+        });
+
+        let exp = Jws::<Bytes, Protected, Header>::Flattened(Flattened {
+            payload: payload.parse().unwrap(),
+            signature: Signature {
+                header: Some(Header {
+                    kid: "e9bc097a-ce51-4036-9562-d2ade882db0d".to_string(),
+                }),
+                protected: Some(Json(Protected {
+                    alg: "ES256".to_string(),
+                })),
+                signature: signature.parse().unwrap(),
+            },
+        });
+
+        assert_eq!(exp, serde_json::from_value(raw).unwrap());
+    }
+
+    // Example from RFC 7515 A.7
+    #[test]
+    fn detached() {
+        let signature = "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q";
+
+        let raw = json!({
+            "protected": "eyJhbGciOiJFUzI1NiJ9",
+            "header": { "kid": "e9bc097a-ce51-4036-9562-d2ade882db0d" },
+            "signature": signature,
+        });
+
+        let exp = Jws::<Option<()>, Protected, Header>::Flattened(Flattened {
+            payload: None,
+            signature: Signature {
+                header: Some(Header {
+                    kid: "e9bc097a-ce51-4036-9562-d2ade882db0d".to_string(),
+                }),
+                protected: Some(Json(Protected {
+                    alg: "ES256".to_string(),
+                })),
+                signature: signature.parse().unwrap(),
+            },
+        });
+
+        assert_eq!(exp, serde_json::from_value(raw).unwrap());
+    }
+}

--- a/crates/jose/src/lib.rs
+++ b/crates/jose/src/lib.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications, clippy::all)]
+#![forbid(unsafe_code, clippy::expect_used, clippy::panic)]
+
+pub mod b64;
+pub mod jws;

--- a/crates/type/Cargo.toml
+++ b/crates/type/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "drawbridge-type"
+version = "0.1.0"
+authors = ["Profian Inc"]
+edition = "2021"
+
+[dependencies]
+drawbridge-byte = { path = "../byte" }
+
+base64 = "0.13.0"
+mime = "0.3.16"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
+tokio = { version = "1.8.0", features = ["rt", "io-util", "macros"] }
+sha2 = "0.10.2"
+
+axum = { version = "0.4.8", features = ["headers"], optional = true }
+headers = { version = "0.3.7", optional = true }
+http = { version = "0.2.6", optional = true }
+
+[features]
+default = []
+server = ["axum", "headers", "http"]

--- a/crates/type/src/digest/algorithm.rs
+++ b/crates/type/src/digest/algorithm.rs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Error, Reader, Writer};
+
+use std::str::FromStr;
+
+use serde::{de::Visitor, Deserialize, Serialize};
+use sha2::{digest::DynDigest, Digest as _, Sha224, Sha256, Sha384, Sha512};
+
+/// A hashing algorithm
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum Algorithm {
+    Sha224,
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl AsRef<str> for Algorithm {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Sha224 => "sha-224",
+            Self::Sha256 => "sha-256",
+            Self::Sha384 => "sha-384",
+            Self::Sha512 => "sha-512",
+        }
+    }
+}
+
+impl std::fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &*s.to_ascii_lowercase() {
+            "sha-224" => Ok(Self::Sha224),
+            "sha-256" => Ok(Self::Sha256),
+            "sha-384" => Ok(Self::Sha384),
+            "sha-512" => Ok(Self::Sha512),
+            _ => Err(Error::UnknownAlgorithm),
+        }
+    }
+}
+
+impl Serialize for Algorithm {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_ref().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Algorithm {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct StrVisitor;
+
+        impl<'de> Visitor<'de> for StrVisitor {
+            type Value = Algorithm;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Content-Digest algorithm name")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                v.parse().map_err(|_| E::custom("unknown algorithm"))
+            }
+
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+                v.parse().map_err(|_| E::custom("unknown algorithm"))
+            }
+        }
+
+        deserializer.deserialize_str(StrVisitor)
+    }
+}
+
+impl Algorithm {
+    pub(crate) fn hasher(self) -> Box<dyn DynDigest> {
+        match self {
+            Self::Sha224 => Box::new(Sha224::new()),
+            Self::Sha256 => Box::new(Sha256::new()),
+            Self::Sha384 => Box::new(Sha384::new()),
+            Self::Sha512 => Box::new(Sha512::new()),
+        }
+    }
+
+    /// Creates a reader instance
+    pub fn reader<T>(&self, reader: T) -> Reader<T> {
+        Reader::new(reader, [*self])
+    }
+
+    /// Creates a writer instance
+    pub fn writer<T>(&self, writer: T) -> Writer<T> {
+        Writer::new(writer, [*self])
+    }
+}

--- a/crates/type/src/digest/algorithms.rs
+++ b/crates/type/src/digest/algorithms.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Algorithm, Reader, Writer};
+
+use std::collections::BTreeSet;
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+
+/// A set of hashing algorithms
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Algorithms(BTreeSet<Algorithm>);
+
+impl Default for Algorithms {
+    fn default() -> Self {
+        let mut set = BTreeSet::new();
+        set.insert(Algorithm::Sha224);
+        set.insert(Algorithm::Sha256);
+        set.insert(Algorithm::Sha384);
+        set.insert(Algorithm::Sha512);
+        Self(set)
+    }
+}
+
+impl From<BTreeSet<Algorithm>> for Algorithms {
+    fn from(value: BTreeSet<Algorithm>) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for Algorithms {
+    type Target = BTreeSet<Algorithm>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Algorithms {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Algorithms {
+    /// Creates a reader instance
+    pub fn reader<T>(&self, reader: T) -> Reader<T> {
+        Reader::new(reader, self.iter().cloned())
+    }
+
+    /// Creates a writer instance
+    pub fn writer<T>(&self, writer: T) -> Writer<T> {
+        Writer::new(writer, self.iter().cloned())
+    }
+}

--- a/crates/type/src/digest/digests.rs
+++ b/crates/type/src/digest/digests.rs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Algorithm, Error, Reader, Verifier, Writer};
+
+use std::collections::btree_map::IntoIter;
+use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
+use drawbridge_byte::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[cfg(all(feature = "headers", feature = "http"))]
+use headers::{Error as HeadErr, Header, HeaderName, HeaderValue};
+
+/// A set of hashes for the same contents
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+pub struct ContentDigest<H = Box<[u8]>>(BTreeMap<Algorithm, Bytes<H>>)
+where
+    H: AsRef<[u8]> + From<Vec<u8>>;
+
+impl<H> ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    /// Creates a reader instance
+    pub fn reader<T>(&self, reader: T) -> Reader<T> {
+        Reader::new(reader, self.iter().map(|x| *x.0))
+    }
+
+    /// Creates a writer instance
+    pub fn writer<T>(&self, writer: T) -> Writer<T> {
+        Writer::new(writer, self.iter().map(|x| *x.0))
+    }
+
+    /// Creates a verifier instance
+    pub fn verifier<T>(self, reader: T) -> Verifier<T, H> {
+        Verifier::new(self.reader(reader), self)
+    }
+}
+
+impl<H> From<BTreeMap<Algorithm, Bytes<H>>> for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn from(value: BTreeMap<Algorithm, Bytes<H>>) -> Self {
+        Self(value)
+    }
+}
+
+impl<H> Eq for ContentDigest<H> where H: AsRef<[u8]> + From<Vec<u8>> {}
+impl<T, U> PartialEq<ContentDigest<U>> for ContentDigest<T>
+where
+    T: AsRef<[u8]> + From<Vec<u8>>,
+    U: AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn eq(&self, other: &ContentDigest<U>) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        for (lhs, rhs) in self.0.iter().zip(other.0.iter()) {
+            if lhs.0 != rhs.0 {
+                return false;
+            }
+
+            if lhs.1.as_ref() != rhs.1.as_ref() {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl<H> Deref for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    type Target = BTreeMap<Algorithm, Bytes<H>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<H> DerefMut for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<H> std::fmt::Display for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut comma = "";
+
+        for (algo, hash) in self.iter() {
+            write!(f, "{}{}=:{}:", comma, algo, hash)?;
+            comma = ",";
+        }
+
+        Ok(())
+    }
+}
+
+impl<H> FromStr for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(
+            s.split(',')
+                .map(|s| {
+                    let (key, val) = s.split_once('=').ok_or(Error::MissingEq)?;
+                    if val.len() < 2 || !val.starts_with(':') || !val.ends_with(':') {
+                        return Err(Error::MissingColons);
+                    }
+
+                    let b64 = &val[1..val.len() - 2];
+                    Ok((key.parse()?, b64.parse()?))
+                })
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+}
+
+impl<H> IntoIterator for ContentDigest<H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    type Item = (Algorithm, Bytes<H>);
+    type IntoIter = IntoIter<Algorithm, Bytes<H>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[cfg(all(feature = "headers", feature = "http"))]
+impl<H> Header for ContentDigest<H>
+where
+    H: Default + AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn name() -> &'static HeaderName {
+        &http::header::CONTENT_DIGEST
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, HeadErr>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let mut all = Self::default();
+
+        for value in values {
+            let digests: ContentDigest<H> = std::str::from_utf8(value.as_bytes())
+                .map_err(|_| HeadErr::invalid())?
+                .parse()
+                .map_err(|_| HeadErr::invalid())?;
+
+            for (algo, hash) in digests {
+                all.insert(algo, hash);
+            }
+        }
+
+        if all.is_empty() {
+            return Err(HeadErr::invalid());
+        }
+
+        Ok(all)
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        let value = HeaderValue::from_str(&self.to_string()).unwrap();
+        values.extend([value].into_iter())
+    }
+}

--- a/crates/type/src/digest/mod.rs
+++ b/crates/type/src/digest/mod.rs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+mod algorithm;
+mod algorithms;
+mod digests;
+mod reader;
+mod verifier;
+mod writer;
+
+pub use algorithm::Algorithm;
+pub use algorithms::Algorithms;
+pub use digests::ContentDigest;
+pub use reader::Reader;
+pub use verifier::Verifier;
+pub use writer::Writer;
+
+/// Parsing error
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+    MissingEq,
+    MissingColons,
+    UnknownAlgorithm,
+    Decode(base64::DecodeError),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decode(e) => e.fmt(f),
+            Self::MissingEq => f.write_str("missing equals"),
+            Self::MissingColons => f.write_str("missing colons"),
+            Self::UnknownAlgorithm => f.write_str("unknown algorithm"),
+        }
+    }
+}
+
+impl From<base64::DecodeError> for Error {
+    fn from(value: base64::DecodeError) -> Self {
+        Self::Decode(value)
+    }
+}

--- a/crates/type/src/digest/reader.rs
+++ b/crates/type/src/digest/reader.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Algorithm, ContentDigest};
+
+use std::pin::Pin;
+use std::task::Context;
+
+use sha2::digest::DynDigest;
+use tokio::io::{AsyncRead, ReadBuf, Result};
+
+/// A hashing reader
+///
+/// This type wraps another reader and hashes the bytes as they are read.
+pub struct Reader<T> {
+    reader: T,
+    digests: Vec<(Algorithm, Box<dyn DynDigest>)>,
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for Reader<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<Result<()>> {
+        let len = buf.filled().len();
+        Pin::new(&mut self.reader).poll_read(cx, buf).map(|r| {
+            r?;
+
+            let filled = buf.filled();
+            for digest in &mut self.digests {
+                digest.1.update(&filled[len..filled.len()]);
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<T> Reader<T> {
+    pub(crate) fn new(reader: T, digests: impl IntoIterator<Item = Algorithm>) -> Self {
+        let digests = digests.into_iter().map(|a| (a, a.hasher())).collect();
+        Reader { reader, digests }
+    }
+
+    /// Calculates the digests for all the bytes written so far.
+    pub fn digests(&self) -> ContentDigest<Box<[u8]>> {
+        let mut set = ContentDigest::default();
+
+        for digest in &self.digests {
+            set.insert(digest.0, digest.1.clone().finalize().into());
+        }
+
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{copy, sink};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn success() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let hash: ContentDigest = HASH.parse().unwrap();
+
+        let mut reader = hash.reader(&b"foo"[..]);
+        copy(&mut reader, &mut sink()).await.unwrap();
+        assert_eq!(reader.digests(), hash);
+    }
+
+    #[tokio::test]
+    async fn failure() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let hash: ContentDigest = HASH.parse().unwrap();
+
+        let mut reader = hash.reader(&b"bar"[..]);
+        copy(&mut reader, &mut sink()).await.unwrap();
+        assert_ne!(reader.digests(), hash);
+    }
+}

--- a/crates/type/src/digest/verifier.rs
+++ b/crates/type/src/digest/verifier.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ContentDigest, Reader};
+
+use std::io::{Error, ErrorKind};
+use std::{pin::Pin, task::Context};
+
+use tokio::io::{AsyncRead, ReadBuf, Result};
+
+/// A verifying reader
+///
+/// This type is exactly the same as [`Reader`](crate::Reader) except that it
+/// additionally verifies the expected hashes. When the end-of-file condition
+/// is reached, if the actual hashes do not match the expected hashes, an error
+/// is produced.
+pub struct Verifier<T, H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    reader: Reader<T>,
+    hashes: ContentDigest<H>,
+}
+
+impl<T, H> Verifier<T, H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    pub(crate) fn new(reader: Reader<T>, hashes: ContentDigest<H>) -> Self {
+        Self { reader, hashes }
+    }
+
+    pub fn digests(&self) -> ContentDigest<Box<[u8]>> {
+        self.reader.digests()
+    }
+}
+
+impl<T: Unpin, H> Unpin for Verifier<T, H> where H: AsRef<[u8]> + From<Vec<u8>> {}
+
+impl<T: AsyncRead + Unpin, H> AsyncRead for Verifier<T, H>
+where
+    H: AsRef<[u8]> + From<Vec<u8>>,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<Result<()>> {
+        let len = buf.filled().len();
+        Pin::new(&mut self.reader).poll_read(cx, buf).map(|r| {
+            match buf.filled().len() - len {
+                // On EOF, validate the hash.
+                0 if buf.capacity() > 0 && self.reader.digests() != self.hashes => {
+                    Err(Error::new(ErrorKind::InvalidData, "hash mismatch"))
+                }
+
+                _ => r,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{copy, sink};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn read_success() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let mut reader = HASH.parse::<ContentDigest>().unwrap().verifier(&b"foo"[..]);
+        copy(&mut reader, &mut sink()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_failure() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let mut reader = HASH.parse::<ContentDigest>().unwrap().verifier(&b"bar"[..]);
+        let err = copy(&mut reader, &mut sink()).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+}

--- a/crates/type/src/digest/writer.rs
+++ b/crates/type/src/digest/writer.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Algorithm, ContentDigest};
+
+use std::task::Context;
+use std::{pin::Pin, task::Poll};
+
+use sha2::digest::DynDigest;
+use tokio::io::{AsyncWrite, Result};
+
+/// A hashing writer
+///
+/// This type wraps another writer and hashes the bytes as they are written.
+pub struct Writer<T> {
+    writer: T,
+    digests: Vec<(Algorithm, Box<dyn DynDigest>)>,
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for Writer<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize>> {
+        Pin::new(&mut self.writer).poll_write(cx, buf).map_ok(|n| {
+            for digest in &mut self.digests {
+                digest.1.update(&buf[..n]);
+            }
+
+            n
+        })
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Pin::new(&mut self.writer).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Pin::new(&mut self.writer).poll_shutdown(cx)
+    }
+}
+
+impl<T> Writer<T> {
+    pub(crate) fn new(writer: T, digests: impl IntoIterator<Item = Algorithm>) -> Self {
+        let digests = digests.into_iter().map(|a| (a, a.hasher())).collect();
+        Writer { writer, digests }
+    }
+
+    /// Calculates the digests for all the bytes written so far.
+    pub fn digests(&self) -> ContentDigest<Box<[u8]>> {
+        let mut set = ContentDigest::default();
+
+        for digest in &self.digests {
+            set.insert(digest.0, digest.1.clone().finalize().into());
+        }
+
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{copy, sink};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn success() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let set = HASH.parse::<ContentDigest>().unwrap();
+
+        let mut writer = set.clone().writer(sink());
+        copy(&mut &b"foo"[..], &mut writer).await.unwrap();
+        assert_eq!(writer.digests(), set);
+    }
+
+    #[tokio::test]
+    async fn failure() {
+        const HASH: &str = "sha-256=:LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=:";
+        let set = HASH.parse::<ContentDigest>().unwrap();
+
+        let mut writer = set.clone().writer(sink());
+        copy(&mut &b"bar"[..], &mut writer).await.unwrap();
+        assert_ne!(writer.digests(), set);
+    }
+}

--- a/crates/type/src/lib.rs
+++ b/crates/type/src/lib.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications, clippy::all)]
+#![forbid(unsafe_code)]
+
+pub mod digest;
+
+mod meta;
+
+pub use self::meta::Meta;
+
+use digest::ContentDigest;
+
+use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+
+/// A directory
+///
+/// A directory is simply a sorted name to `Entry` map.
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Directory(BTreeMap<String, Entry>);
+
+impl Directory {
+    pub const TYPE: &'static str = "application/vnd.drawbridge.directory.v1+json";
+}
+
+impl Deref for Directory {
+    type Target = BTreeMap<String, Entry>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Directory {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// A directory entry
+///
+/// Note that this type is designed to be extensible. Therefore, the fields
+/// here represent the minimum required fields. Other fields may be present.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entry {
+    /// The hash of this entry
+    pub digest: ContentDigest,
+}
+
+impl Entry {
+    #[allow(dead_code)]
+    pub const TYPE: &'static str = "application/vnd.drawbridge.entry.v1+json";
+}

--- a/crates/type/src/meta.rs
+++ b/crates/type/src/meta.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::digest::ContentDigest;
+
+use mime::Mime;
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "axum")]
+use axum::{
+    extract::{rejection::TypedHeaderRejection, FromRequest, RequestParts, TypedHeader},
+    headers::{ContentLength, ContentType},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Meta {
+    #[serde(rename = "digest")]
+    pub hash: ContentDigest<Box<[u8]>>,
+
+    #[serde(rename = "length")]
+    pub size: u64,
+
+    #[serde(deserialize_with = "deserialize")]
+    #[serde(serialize_with = "serialize")]
+    #[serde(rename = "type")]
+    pub mime: Mime,
+}
+
+fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Mime, D::Error> {
+    String::deserialize(deserializer)?
+        .parse()
+        .map_err(|_| D::Error::custom("invalid mime type"))
+}
+
+fn serialize<S: Serializer>(mime: &Mime, serializer: S) -> Result<S::Ok, S::Error> {
+    mime.to_string().serialize(serializer)
+}
+
+#[cfg(feature = "axum")]
+#[axum::async_trait]
+impl<B: Send> FromRequest<B> for Meta {
+    type Rejection = TypedHeaderRejection;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        let hash = TypedHeader::<ContentDigest>::from_request(req).await?.0;
+        let mime = TypedHeader::<ContentType>::from_request(req).await?.0;
+        let size = TypedHeader::<ContentLength>::from_request(req).await?.0;
+
+        Ok(Meta {
+            hash,
+            mime: mime.into(),
+            size: size.0,
+        })
+    }
+}
+
+impl IntoIterator for Meta {
+    type IntoIter = std::array::IntoIter<(&'static str, String), 3>;
+    type Item = (&'static str, String);
+
+    fn into_iter(self) -> Self::IntoIter {
+        [
+            ("Content-Length", self.size.to_string()),
+            ("Content-Digest", self.hash.to_string()),
+            ("Content-Type", self.mime.to_string()),
+        ]
+        .into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    #[test]
+    fn serialization() {
+        let meta = Meta {
+            hash: "sha-384=:mqVuAfXRKap7bdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8w=:"
+                .parse()
+                .unwrap(),
+            size: 42,
+            mime: "text/plain".parse().unwrap(),
+        };
+
+        let json = json!({
+            "digest": {"sha-384": "mqVuAfXRKap7bdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8w="},
+            "length": 42,
+            "type": "text/plain",
+        });
+
+        assert_eq!(serde_json::to_string(&meta).unwrap(), json.to_string());
+    }
+}


### PR DESCRIPTION
This contains types shared by clients and various server components.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>