### PR TITLE
feat(repo): add repository management routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,8 @@ dependencies = [
  "drawbridge-store",
  "drawbridge-tags",
  "drawbridge-tree",
+ "drawbridge-type",
+ "futures 0.3.21",
  "tokio",
  "tower",
 ]

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2021"
 drawbridge-store = { path = "../store" }
 drawbridge-tags = { path = "../tags" }
 drawbridge-tree = { path = "../tree" }
+drawbridge-type = { path = "../type" }
 
 # External dependencies
 axum = { version = "0.5.0" }
+futures = { version = "0.3.21" }
 tokio = { version = "1.17.0" }
 tower = { version = "0.4.12" }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -71,13 +71,16 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let uri = req.uri_mut();
         let path = uri.path().strip_prefix('/').expect("invalid URI");
-        let (namespace, rest) = path.split_once("/_").unwrap_or((path, ""));
+        let (namespace, rest) = path
+            .split_once("/_")
+            .map(|(namespace, rest)| (namespace, format!("_{}", rest)))
+            .unwrap_or((path, "".into()));
         let namespace = namespace
             .parse()
             .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
 
         let mut parts = uri.clone().into_parts();
-        parts.path_and_query = Some(format!("/_{}", rest).parse().unwrap());
+        parts.path_and_query = Some(format!("/{}", rest).parse().unwrap());
         *uri = Uri::from_parts(parts).unwrap();
         Ok(namespace)
     }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -93,8 +93,14 @@ pub trait Keys<K> {
     async fn keys(&self) -> Result<Self::Stream, Self::Error>;
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Memory<K>(HashMap<K, (Meta, Vec<u8>)>);
+
+impl<K> Default for Memory<K> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 
 #[async_trait]
 impl<K> Create<K> for Memory<K>


### PR DESCRIPTION
Added repo management routes, fixed the path parsing

Refs #35 

@rjzak could you (can be follow-up PR):
1. Extract `Namespace`, related parsing and testing logic to `namespace.rs`?
2. Add tests for routing in `lib.rs`?
3. Add repository existence checking (see https://github.com/profianinc/drawbridge/pull/63/files#r854318531)