### PR TITLE
ci: add Commisery workflow

### DIFF
--- a/.github/workflows/commisery.yml
+++ b/.github/workflows/commisery.yml
@@ -1,0 +1,40 @@
+# Copyright (C) 2020-2020, TomTom (http://tomtom.com).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Commisery
+on:
+  pull_request:
+    types: [edited, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commit-message:
+    name: Conventional Commit Message Checker (Commisery)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check-out the repo under $GITHUB_WORKSPACE
+      uses: actions/checkout@v2
+
+    - name: Run Commisery
+      uses: enarx/commisery-action@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pull_request: ${{ github.event.number }}


### PR DESCRIPTION
Enforce https://www.conventionalcommits.org/en/v1.0.0/

Duplicated the workflow directly from latest https://github.com/enarx/enarx