### PR TITLE
feat(client): add client library crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,8 @@ name = "drawbridge"
 version = "0.1.0"
 dependencies = [
  "drawbridge-app",
+ "drawbridge-client",
+ "futures",
  "hyper",
  "tokio",
 ]
@@ -164,6 +166,18 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "serde",
+]
+
+[[package]]
+name = "drawbridge-client"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "drawbridge-jose",
+ "drawbridge-type",
+ "mime",
+ "reqwest",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [workspace]
 members = [
     "crates/byte",
+    "crates/client",
     "crates/hash",
     "crates/jose",
     "crates/store",
@@ -20,6 +21,13 @@ drawbridge-app = { path = "./crates/app" }
 # External dependencies
 hyper = { version = "0.14.18", default-features = false, features = ["http1", "server", "tcp"] }
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+# Internal dependencies
+drawbridge-client = { path = "./crates/client" }
+
+# External dependencies
+futures = { version = "0.3.21", default-features = false }
 
 [patch.crates-io]
 http = { git = "https://github.com/npmccallum/http", rev = "0f4438e7f5107d8b06142894d2d9cd5186b721ab" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "drawbridge-client"
+version = "0.1.0"
+authors = ["Profian Inc"]
+edition = "2021"
+
+[dependencies]
+# Internal dependencies
+drawbridge-jose = { path = "../jose" }
+drawbridge-type = { path = "../type" }
+
+# External dependencies
+bytes = { version = "1.1.0", default-features = false }
+mime = { version = "0.3.16", default-features = false }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "json"] }
+serde_json = { version = "1.0.79", default-features = false, features = ["std"] }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications, clippy::all)]
+#![forbid(unsafe_code)]
+
+mod repo;
+mod tag;
+mod tree;
+
+pub use repo::*;
+pub use tag::*;
+pub use tree::*;
+
+pub use drawbridge_type as types;
+
+pub use mime;
+pub use reqwest::Url;
+
+use drawbridge_type::RepositoryName;
+
+#[derive(Debug)]
+pub struct Client {
+    inner: reqwest::blocking::Client,
+    url: Url,
+}
+
+impl Client {
+    pub fn builder(url: impl Into<Url>) -> ClientBuilder {
+        ClientBuilder::new(url)
+    }
+
+    pub fn repository<'a>(&'a self, name: &'a RepositoryName) -> Repository<'_> {
+        Repository { client: self, name }
+    }
+}
+
+pub struct ClientBuilder {
+    inner: reqwest::blocking::ClientBuilder,
+    url: Url,
+}
+
+impl ClientBuilder {
+    pub fn new(url: impl Into<Url>) -> Self {
+        Self {
+            inner: reqwest::blocking::Client::builder(),
+            url: url.into(),
+        }
+    }
+
+    // TODO: Add configuration
+
+    pub fn build(self) -> Result<Client, reqwest::Error> {
+        self.inner.build().map(|inner| Client {
+            inner,
+            url: self.url,
+        })
+    }
+}

--- a/crates/client/src/repo.rs
+++ b/crates/client/src/repo.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Client, Tag};
+
+use std::error::Error;
+
+use drawbridge_type::{RepositoryConfig, RepositoryName, TagName};
+
+use reqwest::StatusCode;
+
+pub struct Repository<'a> {
+    pub(crate) client: &'a Client,
+    pub(crate) name: &'a RepositoryName,
+}
+
+impl Repository<'_> {
+    pub fn tag<'a>(&'a self, name: &'a TagName) -> Tag<'_> {
+        Tag { repo: self, name }
+    }
+
+    pub fn tags(&self) -> Result<Vec<TagName>, Box<dyn Error>> {
+        let res = self
+            .client
+            .inner
+            .get(self.client.url.join(&format!("{}/_tag", self.name))?)
+            .send()?
+            .error_for_status()?;
+        // TODO: Verify Content-Digest
+        // TODO: Verify Content-Length
+        // https://github.com/profianinc/drawbridge/issues/103
+        match res.status() {
+            StatusCode::OK => res.json().map_err(Into::into),
+            _ => Err("unexpected status code")?,
+        }
+    }
+
+    pub fn create(&self, conf: &RepositoryConfig) -> Result<bool, Box<dyn Error>> {
+        let res = self
+            .client
+            .inner
+            .put(self.client.url.join(&self.name.to_string())?)
+            // TODO: Calculate and set Content-Digest
+            // TODO: Verify if Content-Length header is set
+            // https://github.com/profianinc/drawbridge/issues/102
+            .json(conf)
+            .send()?
+            .error_for_status()?;
+        match res.status() {
+            StatusCode::CREATED => Ok(true),
+            StatusCode::OK => Ok(false),
+            _ => Err("unexpected status code")?,
+        }
+    }
+
+    pub fn get(&self) -> Result<RepositoryConfig, Box<dyn Error>> {
+        let res = self
+            .client
+            .inner
+            .get(self.client.url.join(&self.name.to_string())?)
+            .send()?
+            .error_for_status()?;
+        // TODO: Verify Content-Digest
+        // TODO: Verify Content-Length
+        // https://github.com/profianinc/drawbridge/issues/103
+        match res.status() {
+            StatusCode::OK => res.json().map_err(Into::into),
+            _ => Err("unexpected status code")?,
+        }
+    }
+}

--- a/crates/client/src/tag.rs
+++ b/crates/client/src/tag.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Node, Repository};
+
+use std::error::Error;
+
+use drawbridge_jose::jws::Jws;
+use drawbridge_type::{TagEntry, TagName, TreeEntry, TreePath};
+
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::StatusCode;
+
+pub struct Tag<'a> {
+    pub(crate) repo: &'a Repository<'a>,
+    pub(crate) name: &'a TagName,
+}
+
+impl Tag<'_> {
+    pub fn path<'a>(&'a self, path: &'a TreePath) -> Node<'_> {
+        Node { tag: self, path }
+    }
+
+    pub fn create(&self, entry: &TagEntry) -> Result<bool, Box<dyn Error>> {
+        let body = serde_json::to_vec(&entry)?;
+        let res = self
+            .repo
+            .client
+            .inner
+            .put(
+                self.repo
+                    .client
+                    .url
+                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?,
+            )
+            .header(
+                CONTENT_TYPE,
+                match entry {
+                    TagEntry::Unsigned(..) => TreeEntry::TYPE,
+                    TagEntry::Signed(..) => Jws::TYPE,
+                },
+            )
+            .header(CONTENT_LENGTH, body.len()) // TODO: Verify if this is handled by reqwest
+            // TODO: Calculate and set Content-Digest
+            // https://github.com/profianinc/drawbridge/issues/102
+            .body(body)
+            .send()?
+            .error_for_status()?;
+        match res.status() {
+            StatusCode::CREATED => Ok(true),
+            StatusCode::OK => Ok(false),
+            _ => Err("unexpected status code")?,
+        }
+    }
+
+    pub fn get(&self) -> Result<TagEntry, Box<dyn Error>> {
+        let res = self
+            .repo
+            .client
+            .inner
+            .get(
+                self.repo
+                    .client
+                    .url
+                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?,
+            )
+            .send()?
+            .error_for_status()?;
+        // TODO: Verify Content-Digest
+        // TODO: Verify Content-Length
+        // https://github.com/profianinc/drawbridge/issues/103
+        match res.status() {
+            StatusCode::OK => res.json().map_err(Into::into),
+            _ => Err("unexpected status code")?,
+        }
+    }
+}

--- a/crates/client/src/tree.rs
+++ b/crates/client/src/tree.rs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Tag;
+
+use std::error::Error;
+use std::io::Write;
+
+use drawbridge_type::{Meta, TreePath};
+
+use bytes::Bytes;
+use mime::Mime;
+use reqwest::blocking::{Body, Response};
+use reqwest::header::CONTENT_TYPE;
+use reqwest::StatusCode;
+
+pub struct Node<'a> {
+    pub(crate) tag: &'a Tag<'a>,
+    pub(crate) path: &'a TreePath,
+}
+
+impl Node<'_> {
+    pub fn create(&self, mime: Mime, body: impl Into<Body>) -> Result<bool, Box<dyn Error>> {
+        let res = self
+            .tag
+            .repo
+            .client
+            .inner
+            .put(self.tag.repo.client.url.join(&format!(
+                "{}/_tag/{}/tree{}",
+                self.tag.repo.name, self.tag.name, self.path,
+            ))?)
+            .header(CONTENT_TYPE, mime.to_string())
+            // TODO: Calculate and set Content-Digest
+            // TODO: Verify if Content-Length header is set
+            // https://github.com/profianinc/drawbridge/issues/102
+            .body(body)
+            .send()?
+            .error_for_status()?;
+        match res.status() {
+            StatusCode::CREATED => Ok(true),
+            StatusCode::OK => Ok(false),
+            _ => Err("unexpected status code")?,
+        }
+    }
+
+    fn get(&self) -> Result<(Meta, Response), Box<dyn Error>> {
+        let res = self
+            .tag
+            .repo
+            .client
+            .inner
+            .get(self.tag.repo.client.url.join(&format!(
+                "{}/_tag/{}/tree{}",
+                self.tag.repo.name, self.tag.name, self.path,
+            ))?)
+            .send()?
+            .error_for_status()?;
+        let (hash, mime) = {
+            let hdr = res.headers();
+            (
+                // TODO: figure out why CONTENT_DIGEST does not work
+                // TODO: fix parsing of Content-Digest header
+                //hdr.get("content-digest")
+                //    .ok_or("missing Content-Digest header")?
+                //    .to_str()?
+                //    .parse()
+                //    .map_err(|e| format!("failed to parse Content-Digest value: {}", e))?,
+                // https://github.com/profianinc/drawbridge/issues/103
+                Default::default(),
+                hdr.get(CONTENT_TYPE)
+                    .ok_or("missing Content-Type header")?
+                    .to_str()?
+                    .parse()?,
+            )
+        };
+        let size = res
+            .content_length()
+            .ok_or("missing Content-Length header")?;
+        match res.status() {
+            StatusCode::OK => Ok((Meta { hash, size, mime }, res)),
+            _ => Err("unexpected status code")?,
+        }
+    }
+
+    pub fn get_to(&self, dst: &mut impl Write) -> Result<(u64, Mime), Box<dyn Error>> {
+        let (
+            Meta {
+                // TODO: Validate digest
+                // https://github.com/profianinc/drawbridge/issues/103
+                hash: _,
+                size,
+                mime,
+            },
+            mut res,
+        ) = self.get()?;
+        let n = res.copy_to(dst)?;
+        if n != size {
+            Err(format!(
+                "invalid amount of bytes read, expected {}, read {}",
+                size, n,
+            ))?
+        }
+        Ok((size, mime))
+    }
+
+    pub fn get_bytes(&self) -> Result<(Bytes, Mime), Box<dyn Error>> {
+        let (
+            Meta {
+                // TODO: Validate digest
+                // https://github.com/profianinc/drawbridge/issues/103
+                hash: _,
+                size,
+                mime,
+            },
+            res,
+        ) = self.get()?;
+        let b = res.bytes()?;
+        if b.len() as u64 != size {
+            Err(format!(
+                "invalid amount of bytes read, expected {}, read {}",
+                size,
+                b.len(),
+            ))?
+        }
+        Ok((b, mime))
+    }
+
+    pub fn get_text(&self) -> Result<(String, Mime), Box<dyn Error>> {
+        let (
+            Meta {
+                // TODO: Validate digest
+                // https://github.com/profianinc/drawbridge/issues/103
+                hash: _,
+                size,
+                mime,
+            },
+            res,
+        ) = self.get()?;
+        let s = res.text()?;
+        if s.len() as u64 != size {
+            Err(format!(
+                "invalid amount of bytes read, expected {}, read {}",
+                size,
+                s.len(),
+            ))?
+        }
+        Ok((s, mime))
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,65 @@
+use std::net::{Ipv4Addr, TcpListener};
+
+use drawbridge_app::Builder;
+use drawbridge_client::types::{RepositoryConfig, TagEntry, TreeEntry};
+use drawbridge_client::{mime, Client, Url};
+
+use futures::channel::oneshot::channel;
+use hyper::Server;
+
+#[tokio::test]
+async fn app() {
+    let lis = TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    let addr = format!("http://{}", lis.local_addr().unwrap());
+
+    let (tx, rx) = channel::<()>();
+    let srv = tokio::spawn(
+        Server::from_tcp(lis)
+            .unwrap()
+            .serve(Builder::new().build())
+            .with_graceful_shutdown(async { rx.await.ok().unwrap() }),
+    );
+    let cl = tokio::task::spawn_blocking(move || {
+        let cl = Client::builder(addr.parse::<Url>().unwrap())
+            .build()
+            .unwrap();
+
+        let foo_repo = "user/foo".parse().unwrap();
+        let foo = cl.repository(&foo_repo);
+
+        let bar_repo = "user/test/bar".parse().unwrap();
+        let bar = cl.repository(&bar_repo);
+
+        assert!(matches!(foo.get(), Err(_)));
+        assert!(matches!(bar.get(), Err(_)));
+
+        assert!(matches!(foo.create(&RepositoryConfig {}), Ok(true)));
+        assert!(matches!(bar.create(&RepositoryConfig {}), Ok(true)));
+
+        assert_eq!(foo.tags().unwrap(), vec![]);
+        assert_eq!(bar.tags().unwrap(), vec![]);
+
+        let v0_1_0 = "0.1.0".parse().unwrap();
+        let foo_v0_1_0 = foo.tag(&v0_1_0);
+
+        let entry = TagEntry::Unsigned(TreeEntry {
+            digest: Default::default(),
+            custom: Default::default(),
+        });
+
+        assert!(matches!(foo_v0_1_0.get(), Err(_)));
+        assert!(matches!(foo_v0_1_0.create(&entry), Ok(true)));
+        assert_eq!(foo_v0_1_0.get().unwrap(), entry);
+
+        let root_path = "/".parse().unwrap();
+        let root = foo_v0_1_0.path(&root_path);
+        assert!(matches!(root.get_text(), Err(_)));
+        assert!(matches!(root.create(mime::TEXT_PLAIN, "test"), Ok(true)));
+        assert_eq!(root.get_text().unwrap(), ("test".into(), mime::TEXT_PLAIN));
+    });
+    assert!(matches!(cl.await, Ok(())));
+
+    // Stop server
+    assert_eq!(tx.send(()), Ok(()));
+    assert!(matches!(srv.await, Ok(Ok(()))));
+}


### PR DESCRIPTION
Initial client library implementation. Closes #98 .

There's still work to be done, but this something we can already start building on top of and use for testing.