### PR TITLE
feat: merge `{Request,}Meta`, validate tree leaf node lengths

### DIFF
--- a/crates/app/src/repos.rs
+++ b/crates/app/src/repos.rs
@@ -9,7 +9,7 @@ use drawbridge_store::{
     Create, CreateError, CreateFromReaderError, Get, GetError, GetToWriterError,
 };
 use drawbridge_type::repository::{Config, Name};
-use drawbridge_type::RequestMeta;
+use drawbridge_type::Meta;
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -65,16 +65,14 @@ pub async fn get(
 pub async fn put(
     Extension(repos): Extension<Arc<RepoStore>>,
     Extension(name): Extension<Name>,
-    RequestMeta { hash, size, mime }: RequestMeta,
+    Meta { hash, size, mime }: Meta,
     Json(config): Json<Config>,
 ) -> impl IntoResponse {
     let buf = serde_json::to_vec(&config).unwrap();
-    if let Some(size) = size {
-        if buf.len() as u64 != size {
-            // TODO: Report error location
-            // https://github.com/profianinc/drawbridge/issues/97
-            return Err((StatusCode::BAD_REQUEST, "Invalid repository encoding, make sure the object is minified and keys are sorted lexicographically".into_response()));
-        }
+    if buf.len() as u64 != size {
+        // TODO: Report error location
+        // https://github.com/profianinc/drawbridge/issues/97
+        return Err((StatusCode::BAD_REQUEST, "Invalid repository encoding, make sure the object is minified and keys are sorted lexicographically".into_response()));
     }
     repos
         .write()

--- a/crates/client/src/repo.rs
+++ b/crates/client/src/repo.rs
@@ -41,8 +41,6 @@ impl Repository<'_> {
             .inner
             .put(self.client.url.join(&self.name.to_string())?)
             // TODO: Calculate and set Content-Digest
-            // TODO: Verify if Content-Length header is set
-            // https://github.com/profianinc/drawbridge/issues/102
             .json(conf)
             .send()?
             .error_for_status()?;

--- a/crates/client/src/tree.rs
+++ b/crates/client/src/tree.rs
@@ -32,8 +32,6 @@ impl Node<'_> {
             ))?)
             .header(CONTENT_TYPE, mime.to_string())
             // TODO: Calculate and set Content-Digest
-            // TODO: Verify if Content-Length header is set
-            // https://github.com/profianinc/drawbridge/issues/102
             .body(body)
             .send()?
             .error_for_status()?;


### PR DESCRIPTION
- Make request Content-Length mandatory (which is set by most clients anyway)
- Make request Content-Digest optional
- Closes https://github.com/profianinc/drawbridge/issues/96. If the content length header contains value:
   - greater than body length => the server will block until full contents are received
   - less than body length => the server will only read content length bytes, content digest should be provided to ensure integrity in this case

Refs #102 - `Content-Length` is already computed by default