### PR TITLE
feat(client): rely on anyhow for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,7 @@ dependencies = [
 name = "drawbridge-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bytes",
  "drawbridge-jose",
  "drawbridge-type",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -10,6 +10,7 @@ drawbridge-jose = { path = "../jose" }
 drawbridge-type = { path = "../type" }
 
 # External dependencies
+anyhow = { version = "1.0", default-features = false, features = ["std"] }
 bytes = { version = "1.1.0", default-features = false }
 mime = { version = "0.3.16", default-features = false }
 reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "json"] }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -14,6 +14,7 @@ pub use tree::*;
 
 pub use drawbridge_type as types;
 
+pub use anyhow::Result;
 pub use mime;
 pub use reqwest::Url;
 
@@ -50,10 +51,13 @@ impl ClientBuilder {
 
     // TODO: Add configuration
 
-    pub fn build(self) -> Result<Client, reqwest::Error> {
-        self.inner.build().map(|inner| Client {
-            inner,
-            url: self.url,
-        })
+    pub fn build(self) -> Result<Client> {
+        self.inner
+            .build()
+            .map(|inner| Client {
+                inner,
+                url: self.url,
+            })
+            .map_err(Into::into)
     }
 }

--- a/crates/client/src/repo.rs
+++ b/crates/client/src/repo.rs
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Client, Tag};
-
-use std::error::Error;
+use super::{Client, Result, Tag};
 
 use drawbridge_type::{RepositoryConfig, RepositoryName, TagName};
 
+use anyhow::bail;
 use reqwest::StatusCode;
 
 pub struct Repository<'a> {
@@ -19,7 +18,7 @@ impl Repository<'_> {
         Tag { repo: self, name }
     }
 
-    pub fn tags(&self) -> Result<Vec<TagName>, Box<dyn Error>> {
+    pub fn tags(&self) -> Result<Vec<TagName>> {
         let res = self
             .client
             .inner
@@ -31,11 +30,11 @@ impl Repository<'_> {
         // https://github.com/profianinc/drawbridge/issues/103
         match res.status() {
             StatusCode::OK => res.json().map_err(Into::into),
-            _ => Err("unexpected status code")?,
+            _ => bail!("unexpected status code: {}", res.status()),
         }
     }
 
-    pub fn create(&self, conf: &RepositoryConfig) -> Result<bool, Box<dyn Error>> {
+    pub fn create(&self, conf: &RepositoryConfig) -> Result<bool> {
         let res = self
             .client
             .inner
@@ -47,11 +46,11 @@ impl Repository<'_> {
         match res.status() {
             StatusCode::CREATED => Ok(true),
             StatusCode::OK => Ok(false),
-            _ => Err("unexpected status code")?,
+            _ => bail!("unexpected status code: {}", res.status()),
         }
     }
 
-    pub fn get(&self) -> Result<RepositoryConfig, Box<dyn Error>> {
+    pub fn get(&self) -> Result<RepositoryConfig> {
         let res = self
             .client
             .inner
@@ -63,7 +62,7 @@ impl Repository<'_> {
         // https://github.com/profianinc/drawbridge/issues/103
         match res.status() {
             StatusCode::OK => res.json().map_err(Into::into),
-            _ => Err("unexpected status code")?,
+            _ => bail!("unexpected status code: {}", res.status()),
         }
     }
 }


### PR DESCRIPTION
`enarx` client needs errors that that are `Send` and `Sync` and we need consistent error handling functionality anyway