### PR TITLE
chore: rework CODEOWNERS assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-* @npmccallum @rvolosatovs @rjzak @definitelynobody
+* @profianinc/drawbridge @bstrie @haraldh
+*.rs @profianinc/drawbridge
+/crates/client/**/*.rs @profianinc/drawbridge @bstrie
+/crates/type/**/*.rs @profianinc/drawbridge @bstrie


### PR DESCRIPTION
Created a new @profianinc/drawbridge team, to which I added @rjzak @npmccallum @definitelynobody and myself. The team should review all Rust code in the repository. @haraldh and @bstrie can review everything else.
For Rust code in user-facing client and type crates added @bstrie as a code owner as well.