### PR TITLE
feat(client): migrate to `ureq`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,12 +185,12 @@ name = "drawbridge-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes",
  "drawbridge-jose",
  "drawbridge-type",
+ "http",
  "mime",
- "reqwest",
- "serde_json",
+ "ureq",
+ "url",
 ]
 
 [[package]]
@@ -518,9 +524,9 @@ checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -816,9 +822,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f48b6d60512a392e34dbf7fd456249fd2de3c83669ab642e021903f4015185b"
+checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
 dependencies = [
  "bytes",
  "libc",
@@ -967,9 +973,24 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "ureq"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "url",
+]
 
 [[package]]
 name = "url"
@@ -981,6 +1002,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ drawbridge-type = { path = "../type" }
 
 # External dependencies
 anyhow = { version = "1.0", default-features = false, features = ["std"] }
-bytes = { version = "1.1.0", default-features = false }
+http = { version = "0.2.6", default-features = false }
 mime = { version = "0.3.16", default-features = false }
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "json"] }
-serde_json = { version = "1.0.79", default-features = false, features = ["std"] }
+ureq = { version = "2.4.0", default-features = false, features = ["json"] }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -16,13 +16,13 @@ pub use drawbridge_type as types;
 
 pub use anyhow::Result;
 pub use mime;
-pub use reqwest::Url;
+pub use url::Url;
 
 use drawbridge_type::RepositoryName;
 
 #[derive(Debug)]
 pub struct Client {
-    inner: reqwest::blocking::Client,
+    inner: ureq::Agent,
     url: Url,
 }
 
@@ -37,27 +37,24 @@ impl Client {
 }
 
 pub struct ClientBuilder {
-    inner: reqwest::blocking::ClientBuilder,
+    inner: ureq::AgentBuilder,
     url: Url,
 }
 
 impl ClientBuilder {
     pub fn new(url: impl Into<Url>) -> Self {
         Self {
-            inner: reqwest::blocking::Client::builder(),
+            inner: ureq::AgentBuilder::new(),
             url: url.into(),
         }
     }
 
     // TODO: Add configuration
 
-    pub fn build(self) -> Result<Client> {
-        self.inner
-            .build()
-            .map(|inner| Client {
-                inner,
-                url: self.url,
-            })
-            .map_err(Into::into)
+    pub fn build(self) -> Client {
+        Client {
+            inner: self.inner.build(),
+            url: self.url,
+        }
     }
 }

--- a/crates/client/src/tag.rs
+++ b/crates/client/src/tag.rs
@@ -7,8 +7,8 @@ use drawbridge_jose::jws::Jws;
 use drawbridge_type::{TagEntry, TagName, TreeEntry, TreePath};
 
 use anyhow::bail;
-use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use reqwest::StatusCode;
+use http::header::CONTENT_TYPE;
+use http::StatusCode;
 
 pub struct Tag<'a> {
     pub(crate) repo: &'a Repository<'a>,
@@ -21,7 +21,6 @@ impl Tag<'_> {
     }
 
     pub fn create(&self, entry: &TagEntry) -> Result<bool> {
-        let body = serde_json::to_vec(&entry)?;
         let res = self
             .repo
             .client
@@ -30,24 +29,22 @@ impl Tag<'_> {
                 self.repo
                     .client
                     .url
-                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?,
+                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?
+                    .as_str(),
             )
-            .header(
-                CONTENT_TYPE,
+            // TODO: Calculate and set Content-Digest
+            // https://github.com/profianinc/drawbridge/issues/102
+            .set(
+                CONTENT_TYPE.as_str(),
                 match entry {
                     TagEntry::Unsigned(..) => TreeEntry::TYPE,
                     TagEntry::Signed(..) => Jws::TYPE,
                 },
             )
-            .header(CONTENT_LENGTH, body.len()) // TODO: Verify if this is handled by reqwest
-            // TODO: Calculate and set Content-Digest
-            // https://github.com/profianinc/drawbridge/issues/102
-            .body(body)
-            .send()?
-            .error_for_status()?;
-        match res.status() {
-            StatusCode::CREATED => Ok(true),
-            StatusCode::OK => Ok(false),
+            .send_json(entry)?;
+        match StatusCode::from_u16(res.status()) {
+            Ok(StatusCode::CREATED) => Ok(true),
+            Ok(StatusCode::OK) => Ok(false),
             _ => bail!("unexpected status code: {}", res.status()),
         }
     }
@@ -61,15 +58,15 @@ impl Tag<'_> {
                 self.repo
                     .client
                     .url
-                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?,
+                    .join(&format!("{}/_tag/{}", self.repo.name, self.name))?
+                    .as_str(),
             )
-            .send()?
-            .error_for_status()?;
+            .call()?;
         // TODO: Verify Content-Digest
         // TODO: Verify Content-Length
         // https://github.com/profianinc/drawbridge/issues/103
-        match res.status() {
-            StatusCode::OK => res.json().map_err(Into::into),
+        match StatusCode::from_u16(res.status()) {
+            Ok(StatusCode::OK) => res.into_json().map_err(Into::into),
             _ => bail!("unexpected status code: {}", res.status()),
         }
     }


### PR DESCRIPTION
`reqwest::blocking` client builder attempts to `clone()`, which does not
work within Enarx keeps, migrate to simpler ureq, which works.

Blocked by #113 