### PR TITLE
ci: fix integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
         command: test
         args: --workspace --features integration-tests
       env:
-        GH_DRAWBRIDGE_TOKEN: ${{ secrets.GH_DRAWBRIDGE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,6 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace
-        # TODO: Reenable https://github.com/profianinc/drawbridge/issues/124
-        #args: --workspace --features integration-tests
-        #env:
-        #  GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
-        #  GH_OAUTH_SECRET: ${{ secrets.GH_OAUTH_SECRET }}
-        #  GH_DRAWBRIDGE_TOKEN: ${{ secrets.GH_DRAWBRIDGE_TOKEN }}
+        args: --workspace --features integration-tests
+      env:
+        GH_DRAWBRIDGE_TOKEN: ${{ secrets.GH_DRAWBRIDGE_TOKEN }}

--- a/crates/auth/tests/routes/mod.rs
+++ b/crates/auth/tests/routes/mod.rs
@@ -5,8 +5,6 @@ mod protected;
 mod providers;
 mod status;
 
-use std::env;
-
 use drawbridge_auth::{AuthRedirectRoot, Builder};
 
 use axum::extract::Extension;
@@ -26,10 +24,7 @@ pub fn test_app(host: String) -> Router {
         .nest(
             "/auth",
             Builder::new(host.clone())
-                .github(
-                    env::var("GH_OAUTH_CLIENT_ID").expect("GH_OAUTH_CLIENT_ID env var"),
-                    env::var("GH_OAUTH_SECRET").expect("GH_OAUTH_SECRET env var"),
-                )
+                .github("unused".to_string(), "unused".to_string())
                 .build(),
         )
         .route(STATUS, get(status::status))

--- a/crates/auth/tests/routes/protected.rs
+++ b/crates/auth/tests/routes/protected.rs
@@ -28,7 +28,7 @@ async fn protected_authenticated() {
     let key = RsaPrivateKey::from_pkcs8_der(include_bytes!("../../rsa2048-priv.der")).unwrap();
     let session = Session::new(
         Provider::GitHub,
-        AccessToken::new(env::var("GH_DRAWBRIDGE_TOKEN").expect("GH_DRAWBRIDGE_TOKEN env var")),
+        AccessToken::new(env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env var")),
     );
     let app = test_app("localhost/auth".to_owned());
     let response = app

--- a/crates/auth/tests/routes/status.rs
+++ b/crates/auth/tests/routes/status.rs
@@ -26,7 +26,7 @@ async fn status_authenticated() {
     let key = RsaPrivateKey::from_pkcs8_der(include_bytes!("../../rsa2048-priv.der")).unwrap();
     let session = Session::new(
         Provider::GitHub,
-        AccessToken::new(env::var("GH_DRAWBRIDGE_TOKEN").expect("GH_DRAWBRIDGE_TOKEN env var")),
+        AccessToken::new(env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env var")),
     );
     let app = test_app("localhost/auth".to_owned());
     let response = app


### PR DESCRIPTION
Closes #124

Secrets not being available breaks some tests on pull requests, so these changes will skip tests that rely on them. I also remove some environment variables from the pipeline which are not actually used at the moment.