### PR TITLE
fix: various fixes for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,8 +536,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.6"
-source = "git+https://github.com/npmccallum/http?rev=0f4438e7f5107d8b06142894d2d9cd5186b721ab#0f4438e7f5107d8b06142894d2d9cd5186b721ab"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,3 @@ drawbridge-client = { path = "./crates/client" }
 
 # External dependencies
 futures = { version = "0.3.21", default-features = false }
-
-[patch.crates-io]
-http = { git = "https://github.com/npmccallum/http", rev = "0f4438e7f5107d8b06142894d2d9cd5186b721ab" }

--- a/crates/app/src/trees/mod.rs
+++ b/crates/app/src/trees/mod.rs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
-// SPDX-License-Identifier: Apache-2.0
-
 mod get;
 mod head;
 mod put;

--- a/crates/client/src/tree.rs
+++ b/crates/client/src/tree.rs
@@ -9,7 +9,7 @@ use drawbridge_type::digest::ContentDigest;
 use drawbridge_type::{Meta, TreePath};
 
 use anyhow::{anyhow, bail};
-use http::header::{CONTENT_DIGEST, CONTENT_LENGTH, CONTENT_TYPE};
+use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use http::StatusCode;
 use mime::Mime;
 use ureq::{Request, Response};
@@ -20,7 +20,7 @@ pub struct Node<'a> {
 }
 
 impl Node<'_> {
-    fn create_request(&self, hash: ContentDigest, mime: Mime) -> Result<Request> {
+    fn create_request(&self, _hash: ContentDigest, mime: Mime) -> Result<Request> {
         let req = self
             .tag
             .repo
@@ -37,7 +37,8 @@ impl Node<'_> {
                     ))?
                     .as_str(),
             )
-            .set(CONTENT_DIGEST.as_str(), &hash.to_string())
+            // TODO: Set Content-Digest
+            // https://github.com/profianinc/drawbridge/issues/102
             .set(CONTENT_TYPE.as_str(), &mime.to_string());
         Ok(req)
     }

--- a/crates/type/src/digest/digests.rs
+++ b/crates/type/src/digest/digests.rs
@@ -145,13 +145,15 @@ where
     }
 }
 
+static CONTENT_DIGEST: HeaderName = HeaderName::from_static("content-digest");
+
 #[cfg(all(feature = "headers", feature = "http"))]
 impl<H> Header for ContentDigest<H>
 where
     H: Default + AsRef<[u8]> + From<Vec<u8>>,
 {
     fn name() -> &'static HeaderName {
-        &http::header::CONTENT_DIGEST
+        &CONTENT_DIGEST
     }
 
     fn decode<'i, I>(values: &mut I) -> Result<Self, HeadErr>

--- a/crates/type/src/tree/path.rs
+++ b/crates/type/src/tree/path.rs
@@ -19,7 +19,7 @@ impl FromStr for Path {
             let part = part.as_ref();
             !part.is_empty()
                 && part
-                    .find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_'))
+                    .find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.'))
                     .is_none()
         }
 


### PR DESCRIPTION
- Remove `http` crate patch. We should choose a shared location where the definition of the header should live and use for #102. Maybe just duplicate definition (as a string) in client is fine.
- Allow `.` in tree node names
- Remove duplicate copyright header