### PR TITLE
ci: add @bstrie to repo-wide CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
 * @profianinc/drawbridge @bstrie @haraldh
-*.rs @profianinc/drawbridge
-/crates/client/**/*.rs @profianinc/drawbridge @bstrie
-/crates/type/**/*.rs @profianinc/drawbridge @bstrie
+*.rs @profianinc/drawbridge @bstrie


### PR DESCRIPTION
We might need some help with reviews in the repo, so adding @bstrie as CODEOWNER on the whole codebase, rather than just the user-facing crates.