### PR TITLE
refactor: replace Into<Url> with Url

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn builder(url: impl Into<Url>) -> ClientBuilder {
+    pub fn builder(url: Url) -> ClientBuilder {
         ClientBuilder::new(url)
     }
 
@@ -65,10 +65,10 @@ pub struct ClientBuilder {
 }
 
 impl ClientBuilder {
-    pub fn new(url: impl Into<Url>) -> Self {
+    pub fn new(url: Url) -> Self {
         Self {
             inner: ureq::AgentBuilder::new(),
-            url: url.into(),
+            url,
         }
     }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -10,7 +10,7 @@ use drawbridge_client::types::digest::Algorithms;
 use drawbridge_client::types::{
     Meta, RepositoryConfig, TagEntry, TreeDirectory, TreeEntry, UserConfig,
 };
-use drawbridge_client::{Client, Url};
+use drawbridge_client::Client;
 
 use futures::channel::oneshot::channel;
 use hyper::Server;
@@ -31,7 +31,7 @@ async fn app() {
             .with_graceful_shutdown(async { rx.await.ok().unwrap() }),
     );
     let cl = tokio::task::spawn_blocking(move || {
-        let cl = Client::builder(addr.parse::<Url>().unwrap()).build();
+        let cl = Client::builder(addr.parse().unwrap()).build();
 
         let user_name = "user".parse().unwrap();
         let user = cl.user(&user_name);


### PR DESCRIPTION
There are no implementations of Into/From for URLs, and constructing them from strings is fallible anyway, so we can remove this to improve type inference.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>