### PR TITLE
refactor(app): move tag list hash computation logic into store

### DIFF
--- a/crates/app/src/tags/query.rs
+++ b/crates/app/src/tags/query.rs
@@ -5,11 +5,9 @@ use super::super::Store;
 
 use std::sync::Arc;
 
-use drawbridge_type::digest::Algorithms;
 use drawbridge_type::{Meta, RepositoryContext};
 
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
 use axum::Extension;
 use mime::APPLICATION_JSON;
 
@@ -17,38 +15,22 @@ pub async fn query(
     Extension(store): Extension<Arc<Store>>,
     repo: RepositoryContext,
 ) -> impl IntoResponse {
-    {
-        let tags = store
-            .repository(&repo)
-            .tags()
-            .await
-            .map_err(IntoResponse::into_response)?;
-        // TODO: Optimize hash computation
-        let buf = serde_json::to_vec(&tags).map_err(|e| {
+    store
+        .repository(&repo)
+        .tags_json()
+        .await
+        .map(|(hash, buf)| {
             (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to encode tags as JSON: {e}"),
+                Meta {
+                    hash,
+                    size: buf.len() as _,
+                    mime: APPLICATION_JSON,
+                },
+                buf,
             )
-                .into_response()
-        })?;
-        let hash = Algorithms::default().read_sync(&buf[..]).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to compute tag digest: {e}"),
-            )
-                .into_response()
-        })?;
-        Ok::<_, Response>((
-            Meta {
-                hash,
-                size: buf.len() as _,
-                mime: APPLICATION_JSON,
-            },
-            buf,
-        ))
-    }
-    .map_err(|e| {
-        eprintln!("Failed to GET tags on `{}`: {:?}", repo, e);
-        e
-    })
+        })
+        .map_err(|e| {
+            eprintln!("Failed to GET tags on `{}`: {:?}", repo, e);
+            e
+        })
 }


### PR DESCRIPTION
`store` module may cache and/or store the value directly as JSON, therefore such functionality belongs there and not on the API level.