### PR TITLE
feat(tree): enforce client cert auth on tree fetches

### DIFF
--- a/crates/app/src/trees/get.rs
+++ b/crates/app/src/trees/get.rs
@@ -1,16 +1,28 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::Store;
+use super::super::{Store, TrustedCertificate};
 
 use drawbridge_type::TreeContext;
 
 use async_std::sync::Arc;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use log::warn;
 
-pub async fn get(Extension(store): Extension<Arc<Store>>, tree: TreeContext) -> impl IntoResponse {
+pub async fn get(
+    Extension(store): Extension<Arc<Store>>,
+    cert: Option<Extension<TrustedCertificate>>,
+    tree: TreeContext,
+) -> impl IntoResponse {
+    if !cert.is_some() {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "this operation requires either a valid client certificate signed by the Steward or a valid user session authentication",
+        ).into_response());
+    }
+
     // TODO: Stream body
     // https://github.com/profianinc/drawbridge/issues/56
     let mut body = vec![];
@@ -20,7 +32,7 @@ pub async fn get(Extension(store): Extension<Arc<Store>>, tree: TreeContext) -> 
         .await
         .map_err(|e| {
             warn!(target: "app::trees::get", "failed for `{tree}`: {:?}", e);
-            e
+            e.into_response()
         })
         .map(|meta| (meta, body))
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -182,10 +182,8 @@ async fn app() {
         assert_eq!(bar.tags().unwrap(), vec![v0_1_0.clone()]);
 
         let test_file = "test-file.txt".parse().unwrap();
-        assert_eq!(
-            foo.tag(&v0_1_0).path(&test_file).get_string().unwrap(),
-            (APPLICATION_OCTET_STREAM, "text".into())
-        );
+        // TODO: This should succeed once user auth is implemented.
+        assert!(foo.tag(&v0_1_0).path(&test_file).get_string().is_err());
 
         let test_file_cx = TreeContext {
             tag: "user/foo:0.1.0".parse().unwrap(),
@@ -195,10 +193,7 @@ async fn app() {
             cert_cl.tree(&test_file_cx).get_string().unwrap(),
             (APPLICATION_OCTET_STREAM, "text".into())
         );
-        assert_eq!(
-            anon_cl.tree(&test_file_cx).get_string().unwrap(),
-            (APPLICATION_OCTET_STREAM, "text".into())
-        );
+        assert!(anon_cl.tree(&test_file_cx).get_string().is_err());
     });
     assert!(matches!(cl.await.await, ()));
 


### PR DESCRIPTION
Only allow to fetch a tree to clients that have presented a certificate signed by a CA Drawbridge is aware of (normally, Steward).

Tests should still be updated. Refs #186 
Preferably #186 should be done before this PR

With server running as:
```
RUST_LOG=trace cargo run -- --ca testdata/ca.crt --cert testdata/server.crt --key testdata/server.key --store $(mktemp -d)
```

Test via:
```
curl -vv --cacert testdata/ca.crt --cert testdata/client.crt --key testdata/client.key https://localhost:8080/user/repo/_tag/0.1.0/tree/test
```

and

```
curl -vv --cacert testdata/ca.crt https://localhost:8080/user/repo/_tag/0.1.0/tree/test
```