### PR TITLE
feat: make github username and id available in Session

### DIFF
--- a/crates/auth/src/providers/github/mod.rs
+++ b/crates/auth/src/providers/github/mod.rs
@@ -42,12 +42,14 @@ impl fmt::Display for ValidateError {
 
 impl std::error::Error for ValidateError {}
 
-pub async fn validate(session: &Session) -> Result<String, ValidateError> {
-    #[derive(Deserialize)]
-    struct User {
-        login: String,
-    }
+#[derive(Deserialize)]
+pub struct GitHubUser {
+    #[serde(rename = "login")]
+    pub username: String,
+    pub id: u64,
+}
 
+pub async fn validate(session: &Session) -> Result<GitHubUser, ValidateError> {
     #[derive(Deserialize)]
     struct Error {
         message: String,
@@ -62,10 +64,7 @@ pub async fn validate(session: &Session) -> Result<String, ValidateError> {
         .call()
         .map_err(ValidateError::Http)?;
     match StatusCode::from_u16(res.status()) {
-        Ok(s) if s.is_success() => res
-            .into_json()
-            .map_err(ValidateError::Json)
-            .map(|User { login }| login),
+        Ok(s) if s.is_success() => res.into_json().map_err(ValidateError::Json),
         Ok(_) => res
             .into_json()
             .map_err(ValidateError::Json)

--- a/crates/auth/src/providers/github/routes.rs
+++ b/crates/auth/src/providers/github/routes.rs
@@ -40,7 +40,6 @@ pub async fn authorized(
         .request(http_client)
         .map_err(|e| format!("Failed to get token: {}", e))?;
 
-    // TODO: pull user info from the GitHub API here: https://github.com/profianinc/drawbridge/issues/7
     Session::new(Provider::GitHub, token.access_token().clone())
         .encrypt(&key.0)
         .map_err(|e| format!("Failed to encrypt token: {}", e))


### PR DESCRIPTION
Closes #7

Username can also be used to store email or any other printable user identifier just for displaying purposes in another provider.