### PR TITLE
refactor: improve CLI config handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,6 @@ dependencies = [
  "rustls-pemfile",
  "serde_json",
  "tempfile",
- "toml",
 ]
 
 [[package]]
@@ -1971,15 +1970,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ clap = { version = "3.2.3", default-features = false, features = ["derive", "std
 env_logger = { version = "0.9.0", default-features = false, features = ["atty", "termcolor"] }
 futures = { version = "0.3.21", default-features = false }
 log = { version = "0.4.17", default-features = false }
-toml = { version = "0.5.9", default-features = false }
 
 [dev-dependencies]
 # Internal dependencies


### PR DESCRIPTION
Rather than postprocessing the output of Clap, inject the config file values by preprocessing the raw program arguments. This makes the Clap-generated help output more useful, provides better error messages, requires less code, doesn't require a TOML dependency, doesn't restrict our CLI options to forms that can be easily represented in TOML, and has direct precedence from how command-line config files are used in the Java, Python, and C# ecosystems.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>