### PR TITLE
feat: support TOML in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "rustls-pemfile",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -1786,6 +1787,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "3.2.3", default-features = false, features = ["derive", "std
 env_logger = { version = "0.9.0", default-features = false, features = ["atty", "termcolor"] }
 futures = { version = "0.3.21", default-features = false }
 log = { version = "0.4.17", default-features = false }
+toml = { version = "0.5.9", default-features = false }
 
 [dev-dependencies]
 # Internal dependencies


### PR DESCRIPTION
Follow-up on #213 
Closes #193 

A few problems with existing approach:
Config file of form
```toml
ca = "testdata/ca.crt"
cert = "testdata/server.crt" 
key = "testdata/server.key" 
store = "testdata"
oidc-secret = "mysecret"
oidc-client = "myclient" 
oidc-label = "mylabel"
oidc-issuer = "myissuer"
```
fails to parse:
```
error: Found argument 'ca = "testdata/ca.crt"' which wasn't expected, or isn't valid in this context

USAGE:
    drawbridge [OPTIONS] --store <STORE> --cert <CERT> --key <KEY> --ca <CA> --oidc-label <OIDC_LABEL> --oidc-issuer <OIDC_ISSUER> --oidc-client <OIDC_CLIENT>

For more information try --help
```

Same behavior with:
- `ca="testdata/ca.crt"`
- `ca "testdata/ca.crt"`
- `ca testdata/ca.crt`

The implementation expects the file to contain the actual command-line arguments in the file, that means it's just a convenience over doing `drawbridge $(cat args)`, which is not what we want.

With this PR in place we enforce TOML in config files, which means that the configuration file format is non-surprising and obvious

Example error:
```
cargo run -- @config.tom
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/drawbridge '@config.tom'`
Error: Failed to parse arguments

Caused by:
    0: failed to read config file at `config.tom`
    1: No such file or directory (os error 2)
```