### PR TITLE
build(nix): update flake syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,5 @@ jobs:
     - uses: cachix/install-nix-action@v17
     - name: nix flake check
       run: nix flake check
+    - name: nix fmt
+      run: nix fmt ./flake.nix ./shell.nix

--- a/flake.nix
+++ b/flake.nix
@@ -71,15 +71,14 @@
       };
     in
     {
-      defaultPackage = nativeBin;
-
       packages = {
         "${cargo.toml.package.name}" = nativeBin;
         "${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
         "${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
       };
+      packages.default = nativeBin;
 
-      devShell = pkgs.mkShell {
+      devShells.default = pkgs.mkShell {
         buildInputs = [
           pkgs.openssl
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,14 @@
 let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
 
-  fetchInputFromGithub = name: with lock.nodes.${name}.locked; builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
-    sha256 = narHash;
-  };
+  fetchInputFromGithub = name:
+    with lock.nodes.${name}.locked;
+      builtins.fetchTarball {
+        url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+        sha256 = narHash;
+      };
   flakeCompat = fetchInputFromGithub "flake-compat";
 
-  flake = import flakeCompat { src = ./.; };
+  flake = import flakeCompat {src = ./.;};
 in
-flake.shellNix
+  flake.shellNix


### PR DESCRIPTION
nix 2.8 was released recently, which updated the flake syntax

Updated the flake to the changes, set up a default formatter and formatted relevant files