### PR TITLE
feat(app): use `RequestBody` auth

### DIFF
--- a/crates/app/src/auth/oidc.rs
+++ b/crates/app/src/auth/oidc.rs
@@ -101,13 +101,15 @@ impl<B: Send> FromRequest<B> for Claims {
         })?;
 
         trace!(target: "app:auth::oidc", "request user info");
-        info_req.request(http_client).map(Self).map_err(|e| {
+        let claims = info_req.request(http_client).map_err(|e| {
             debug!(target: "app::auth::oidc", "failed to request user info: {e}");
             (
                 StatusCode::UNAUTHORIZED,
                 format!("OpenID Connect credential validation failed: {e}"),
             )
                 .into_response()
-        })
+        })?;
+        trace!(target: "app:auth::oidc", "received user claims: {:?}", claims);
+        Ok(Self(claims))
     }
 }

--- a/crates/app/src/builder.rs
+++ b/crates/app/src/builder.rs
@@ -16,7 +16,7 @@ use futures_rustls::TlsAcceptor;
 use openidconnect::core::{CoreClient, CoreProviderMetadata};
 use openidconnect::ureq::http_client;
 use openidconnect::url::Url;
-use openidconnect::{ClientId, ClientSecret, IssuerUrl};
+use openidconnect::{AuthType, ClientId, ClientSecret, IssuerUrl};
 
 /// OpenID Connect client configuration.
 pub struct OidcConfig {
@@ -57,7 +57,8 @@ impl<S: AsRef<Path>> Builder<S> {
             oidc_md,
             ClientId::new(self.oidc.client_id),
             self.oidc.client_secret.map(ClientSecret::new),
-        );
+        )
+        .set_auth_type(AuthType::RequestBody);
 
         Ok(App {
             make_service: Mutex::new(


### PR DESCRIPTION
This eliminates the need for client secret

cc @definitelynobody @bstrie 