### PR TITLE
fix: make drawbridge-type compile with default feature set

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -801,7 +801,6 @@ in
     registry = "unknown";
     src = fetchCrateLocal (workspaceSrc + "/crates/type");
     features = builtins.concatLists [
-      [ "anyhow" ]
       [ "axum" ]
       [ "default" ]
       [ "headers" ]

--- a/crates/type/Cargo.toml
+++ b/crates/type/Cargo.toml
@@ -10,7 +10,7 @@ drawbridge-byte = { path = "../byte" }
 drawbridge-jose = { path = "../jose" }
 
 # External dependencies
-anyhow = { version = "1.0.57", default-features = false, features = ["std"], optional = true }
+anyhow = { version = "1.0.57", default-features = false, features = ["std"] }
 base64 = { version = "0.13.0", default-features = false, features = ["std"] }
 futures = { version = "0.3.21", default-features = false, features = ["std"] }
 mime = { version = "0.3.16", default-features = false }
@@ -30,4 +30,4 @@ tempfile = { version = "3.3.0", default-features = false }
 
 [features]
 default = []
-server = ["anyhow", "axum", "futures/async-await", "headers", "http"]
+server = ["axum", "futures/async-await", "headers", "http"]


### PR DESCRIPTION
Previously the `anyhow` crate was only enabled with the `server` feature enabled, which caused compilation failures when that feature was absent.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>