### PR TITLE
feat(client): add scope support

### DIFF
--- a/crates/client/src/tree.rs
+++ b/crates/client/src/tree.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::{Entity, Result};
+use super::{scope, Entity, Result, Scope};
 
 use std::io::Read;
 use std::ops::Deref;
@@ -11,18 +11,18 @@ use drawbridge_type::{Meta, TreeDirectory, TreeEntry, TreePath};
 use mime::Mime;
 use ureq::serde::Serialize;
 
-pub struct Node<'a>(Entity<'a>);
+pub struct Node<'a, S: Scope>(Entity<'a, S, scope::Node>);
 
-impl<'a> Deref for Node<'a> {
-    type Target = Entity<'a>;
+impl<'a, S: Scope> Deref for Node<'a, S> {
+    type Target = Entity<'a, S, scope::Node>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Node<'a> {
-    pub fn new(entity: Entity<'a>, path: &TreePath) -> Self {
+impl<'a, S: Scope> Node<'a, S> {
+    pub fn new(entity: Entity<'a, S, scope::Node>, path: &TreePath) -> Self {
         if path.is_empty() {
             Self(entity)
         } else {

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::{Entity, Repository, Result};
+use super::{scope, Entity, Repository, Result, Scope};
 
 use std::ops::Deref;
 
@@ -10,18 +10,18 @@ use drawbridge_type::{RepositoryName, UserName, UserRecord};
 use mime::APPLICATION_JSON;
 
 #[repr(transparent)]
-pub struct User<'a>(Entity<'a>);
+pub struct User<'a, S: Scope>(Entity<'a, S, scope::User>);
 
-impl<'a> Deref for User<'a> {
-    type Target = Entity<'a>;
+impl<'a, S: Scope> Deref for User<'a, S> {
+    type Target = Entity<'a, S, scope::User>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> User<'a> {
-    pub fn new(entity: Entity<'a>, name: &UserName) -> Self {
+impl<'a, S: Scope> User<'a, S> {
+    pub fn new(entity: Entity<'a, S, scope::Root>, name: &UserName) -> Self {
         User(entity.child(&name.to_string()))
     }
 
@@ -30,10 +30,11 @@ impl<'a> User<'a> {
     }
 
     pub fn get(&self) -> Result<UserRecord> {
-        self.0.get_json()
+        // TODO: Use a reasonable byte limit
+        self.0.get_json(u64::MAX).map(|(_, v)| v)
     }
 
-    pub fn repository(&self, name: &RepositoryName) -> Repository<'a> {
+    pub fn repository(&self, name: &RepositoryName) -> Repository<'a, S> {
         Repository::new(self.0.clone(), name)
     }
 }


### PR DESCRIPTION
Client and Entities using it are now each assigned a "scope", which means that we can safely reuse the client we already have, which is designed for the "root" scope for other scopes.
This is particularly relevant in `exec-wasmtime`, where we get a URL of an unknown "scope" (it may be a URL of the tag, directory or the WASM itself).
This functionality lets us programmatically "scope" an entity after e.g. validating the MIME type. (exact process of how that works is up to the user of the crate to decide, a.k.a it's an out-of-band process from perspective of this crate)

See https://github.com/enarx/enarx/pull/2118 for an example usage