### PR TITLE
feat: add API forwards-compatibility

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -35,6 +35,9 @@ use rustls::kx_group::{SECP256R1, SECP384R1, X25519};
 use rustls::version::TLS13;
 use rustls::{Certificate, OwnedTrustAnchor, PrivateKey, RootCertStore};
 
+/// API version used by this crate
+pub const API_VERSION: &str = "0.1.0";
+
 mod private {
     pub trait Scope: Copy + Clone {}
 }
@@ -213,7 +216,7 @@ impl ClientBuilder<scope::Root> {
     pub fn build(self) -> Result<Client<scope::Root>> {
         let url = self
             .url
-            .join(&format!("api/v{}", env!("CARGO_PKG_VERSION")))
+            .join(&format!("api/v{API_VERSION}"))
             .context("failed to construct URL")?;
         Self { url, ..self }.build_scoped()
     }

--- a/crates/server/src/handle.rs
+++ b/crates/server/src/handle.rs
@@ -43,7 +43,10 @@ pub async fn handle(mut req: Request<Body>) -> impl IntoResponse {
             format!("Failed to parse SemVer version from {path}: {e}"),
         )
     })?;
-    if ver > *API_VERSION {
+    if ver > *API_VERSION
+        && (ver.major > API_VERSION.major
+            || API_VERSION.major == 0 && ver.minor > API_VERSION.minor)
+    {
         return Err((
             StatusCode::NOT_IMPLEMENTED,
             format!("Unsupported API version `{ver}`"),


### PR DESCRIPTION
1. Use the lowest possible API version client-side
2. Allow versions higher than of the server itself within the same major (or minor for v0.*)