### PR TITLE
fix(client): disable response encoding

### DIFF
--- a/crates/client/src/entity.rs
+++ b/crates/client/src/entity.rs
@@ -143,6 +143,7 @@ impl<'a, C: Scope, E: Scope> Entity<'a, C, E> {
             req = req.set("Authorization", &format!("Bearer {token}"))
         }
         let res = req
+            .set("Accept-Encoding", "")
             .call()
             .map_err(parse_ureq_error)
             .context("GET request failed")?;


### PR DESCRIPTION
This fixes https://github.com/enarx/enarx/issues/2087. When `ureq` is imported with `gzip` feature, `Accept-Encoding` is set, which breaks the Drawbridge client, since in that case `Content-Length` is not set. Current implementation of Drawbridge requires full response to be sent verbatim without encoding.

Regarding https://github.com/enarx/enarx/issues/2087#issuecomment-1208586008, that is out-of-scope, because there is no support for streaming in Drawbridge client, this PR is a bug fix. Streaming/chunked transfer feature will be implemented as part of https://github.com/profianinc/drawbridge/issues/255