### PR TITLE
feat(type): make `TreeName` and `TreePath` more useful

### DIFF
--- a/crates/type/src/tree/name.rs
+++ b/crates/type/src/tree/name.rs
@@ -26,6 +26,7 @@ impl FromStr for Name {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty()
             || s.find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.'))
+            || s.find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.' | ':'))
                 .is_some()
         {
             Err(anyhow!("invalid characters in entry name"))

--- a/crates/type/src/tree/name.rs
+++ b/crates/type/src/tree/name.rs
@@ -5,6 +5,7 @@ use super::Path;
 
 use std::fmt::Display;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::anyhow;
@@ -19,20 +20,23 @@ impl Name {
     }
 }
 
-impl FromStr for Name {
-    type Err = anyhow::Error;
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
 
-    #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty()
-            || s.find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.'))
-            || s.find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.' | ':'))
-                .is_some()
-        {
-            Err(anyhow!("invalid characters in entry name"))
-        } else {
-            Ok(Self(s.into()))
-        }
+impl AsRef<String> for Name {
+    fn as_ref(&self) -> &String {
+        &self.0
+    }
+}
+
+impl Deref for Name {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -42,17 +46,31 @@ impl Display for Name {
     }
 }
 
-impl AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        self
+impl From<Name> for PathBuf {
+    fn from(name: Name) -> Self {
+        Self::from(name.0)
     }
 }
 
-impl Deref for Name {
-    type Target = String;
+impl From<Name> for String {
+    fn from(name: Name) -> Self {
+        name.0
+    }
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl FromStr for Name {
+    type Err = anyhow::Error;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty()
+            || s.find(|c| !matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z' | '-' | '_' | '.' | ':'))
+                .is_some()
+        {
+            Err(anyhow!("invalid characters in entry name"))
+        } else {
+            Ok(Self(s.into()))
+        }
     }
 }
 

--- a/crates/type/src/tree/path.rs
+++ b/crates/type/src/tree/path.rs
@@ -5,20 +5,13 @@ use super::Name;
 
 use std::fmt::Display;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Path(Vec<Name>);
-
-impl Deref for Path {
-    type Target = Vec<Name>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl Path {
     pub const ROOT: Self = Self(vec![]);
@@ -42,9 +35,41 @@ impl Path {
     }
 }
 
+impl AsRef<Vec<Name>> for Path {
+    fn as_ref(&self) -> &Vec<Name> {
+        &self.0
+    }
+}
+
+impl AsRef<[Name]> for Path {
+    fn as_ref(&self) -> &[Name] {
+        &self.0
+    }
+}
+
+impl Deref for Path {
+    type Target = Vec<Name>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.intersperse("/"))
+    }
+}
+
 impl From<Name> for Path {
     fn from(name: Name) -> Self {
         Self(vec![name])
+    }
+}
+
+impl From<Path> for PathBuf {
+    fn from(path: Path) -> Self {
+        path.into_iter().map(PathBuf::from).collect()
     }
 }
 
@@ -66,9 +91,12 @@ impl FromStr for Path {
     }
 }
 
-impl Display for Path {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.intersperse("/"))
+impl IntoIterator for Path {
+    type Item = Name;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 


### PR DESCRIPTION
These types are used (temporarily, until they are moved) in Enarx for VFS implementation.
A few improvements that make that possible