### PR TITLE
build: push containers to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,48 @@ jobs:
         path: drawbridge-${{ matrix.platform.target }}-oci
     - run: ${{ matrix.platform.test-oci }}
 
+  push_oci:
+    needs: build
+    permissions:
+      actions: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: drawbridge-aarch64-unknown-linux-musl-oci
+    - uses: actions/download-artifact@v3
+      with:
+        name: drawbridge-x86_64-unknown-linux-musl-oci
+    - run: skopeo copy docker-archive:./drawbridge-aarch64-unknown-linux-musl-oci containers-storage:localhost/drawbridge:aarch64
+    - run: skopeo copy docker-archive:./drawbridge-x86_64-unknown-linux-musl-oci containers-storage:localhost/drawbridge:x86_64
+    - run: podman image ls
+    - run: podman manifest create drawbridge:manifest
+    - run: podman manifest add drawbridge:manifest containers-storage:localhost/drawbridge:aarch64 --arch=arm64
+    - run: podman manifest add drawbridge:manifest containers-storage:localhost/drawbridge:x86_64 --arch=amd64
+    - run: podman manifest inspect drawbridge:manifest
+    - name: metadata
+      id: metadata
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/profianinc/drawbridge
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+        sep-tags: " "
+    - name: add tags
+      if: github.event_name == 'push'
+      run: podman tag drawbridge:manifest ${{ steps.metadata.outputs.tags }}
+    - name: push to GitHub Packages
+      if: github.event_name == 'push'
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.metadata.outputs.tags }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
   release:
     needs: build
     permissions:


### PR DESCRIPTION
This creates a manifest of the OCI images, and pushes this to GitHub Packages.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>