### PR TITLE
feat: remove oidc symlinks

### DIFF
--- a/crates/server/src/builder.rs
+++ b/crates/server/src/builder.rs
@@ -81,7 +81,7 @@ impl<S: AsRef<Path>> Builder<S> {
         let Self { store, tls, oidc } = self;
         let store_path = store.as_ref();
         let store = File::open(store_path)
-            .and_then(|f| Store::new(Dir::from_std_file(f), oidc.label))
+            .and_then(|f| Store::new(Dir::from_std_file(f)))
             .await
             .context(anyhow!(
                 "failed to open store at `{}`",

--- a/crates/server/src/users/put.rs
+++ b/crates/server/src/users/put.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{GetError, OidcClaims, Store};
+use super::super::{OidcClaims, Store};
 
 use drawbridge_type::{Meta, UserContext, UserRecord};
 
@@ -9,7 +9,7 @@ use async_std::sync::Arc;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 pub async fn put(
     Extension(ref store): Extension<Arc<Store>>,
@@ -22,27 +22,6 @@ pub async fn put(
 
     if record.subject != claims.subject().as_str() {
         return Err((StatusCode::UNAUTHORIZED, "OpenID Connect subject mismatch").into_response());
-    }
-
-    // TODO: Remove this check once there is support for transactions and rollbacks.
-    // https://github.com/profianinc/drawbridge/issues/144
-    let subj = claims.subject();
-    match store.user_by_subject(subj).await {
-        Err(GetError::NotFound) => (),
-        Err(e) => {
-            warn!(target: "app::users::put", "failed to get user by OpenID Connect subject `{}`: {:?}", subj.as_str(), e);
-            return Err(e.into_response());
-        }
-        Ok(_) => {
-            return Err((
-                StatusCode::CONFLICT,
-                format!(
-                    "User already associated with OpenID Connect subject `{}`",
-                    subj.as_str()
-                ),
-            )
-                .into_response())
-        }
     }
 
     store

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -198,16 +198,13 @@ async fn app() {
                 subject: format!("{}other", user_record.subject),
             })
             .is_err());
-        assert_eq!(
-            oidc_user
-                .create(&user_record)
-                .expect("failed to create user"),
-            true
-        );
+        assert!(oidc_user
+            .create(&user_record)
+            .expect("failed to create user"));
         assert!(oidc_cl
             .user(&format!("{user_name}other").parse().unwrap())
             .create(&user_record)
-            .is_err());
+            .expect("failed to create other user"));
 
         assert!(anon_user.get().is_err());
         assert!(cert_user.get().is_err());


### PR DESCRIPTION
Remove the symlink from the oidc/ folder that points to the registered username.

This does result in allowing a single OIDC user to create multiple Drawbridge users.

Fixes: #298
Signed-off-by: Patrick Uiterwijk <patrick@profian.com>