### PR TITLE
feat: require Drawbridge username to match OIDC nickname

### DIFF
--- a/crates/server/src/users/put.rs
+++ b/crates/server/src/users/put.rs
@@ -20,6 +20,21 @@ pub async fn put(
 ) -> impl IntoResponse {
     trace!(target: "app::users::put", "called for `{cx}`");
 
+    if let Some(nickname) = claims.nickname().and_then(|n| n.get(None)) {
+        if nickname.as_str() != *cx.name {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                "Username and OpenID Connect nickname mismatch",
+            )
+                .into_response());
+        }
+    } else {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "OpenID Connect nickname not present",
+        )
+            .into_response());
+    }
     if record.subject != claims.subject().as_str() {
         return Err((StatusCode::UNAUTHORIZED, "OpenID Connect subject mismatch").into_response());
     }


### PR DESCRIPTION
This is an alternative/follow-up on #306, where there is an added requirement: the Drawbridge username has to match the OIDC nickname claim (which by GitHub is set to be identical to their GitHub username).

However, this does not prevent people using other users they are mentioned in.
This still allows for vanity/company names to be created on Drawbridge by administrators, and then managed by users via the normal APIs, it just prevents those users from getting created by normal users.
A future improvement could be to add an admin API, or allow certain OIDC subjects to create usernames that are not themselves.