### PR TITLE
feat: enable real multi-user access

### DIFF
--- a/crates/server/src/users/put.rs
+++ b/crates/server/src/users/put.rs
@@ -24,8 +24,12 @@ pub async fn put(
         .assert_scope(ScopeContext::User, ScopeLevel::Write)
         .map_err(IntoResponse::into_response)?;
 
-    if record.subject != claims.subject() {
-        return Err((StatusCode::UNAUTHORIZED, "OpenID Connect subject mismatch").into_response());
+    if !record.contains_subject(claims.subject()) {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "OpenID Connect subject not listed",
+        )
+            .into_response());
     }
 
     store

--- a/crates/type/src/user/record.rs
+++ b/crates/type/src/user/record.rs
@@ -1,12 +1,80 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use serde::{
+    de::{self, Deserializer, MapAccess, Visitor},
+    Deserialize, Serialize,
+};
 
 /// A user record
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Record {
-    /// OpenID Connect identity subject uniquely identifying the user
-    pub subject: String,
+    /// OpenID Connect identity subjects uniquely identifying the users with access
+    pub subjects: Vec<String>,
+}
+
+impl Record {
+    pub fn new(subject: String) -> Self {
+        Self {
+            subjects: vec![subject],
+        }
+    }
+
+    pub fn contains_subject(&self, subject: &str) -> bool {
+        self.subjects.iter().any(|s| s == subject)
+    }
+}
+
+/// Custom Deserializer, in order to allow either the old singular Subject or the new
+/// plural Subjects fields.
+impl<'de> Deserialize<'de> for Record {
+    fn deserialize<D>(deserializer: D) -> Result<Record, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Subject,
+            Subjects,
+        }
+
+        struct RecordVisitor;
+
+        #[allow(single_use_lifetimes)]
+        impl<'de> Visitor<'de> for RecordVisitor {
+            type Value = Record;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("user record struct")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Record, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                if let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Subject => {
+                            let subject = map.next_value()?;
+                            return Ok(Record {
+                                subjects: vec![subject],
+                            });
+                        }
+                        Field::Subjects => {
+                            let subjects = map.next_value()?;
+                            return Ok(Record { subjects });
+                        }
+                    }
+                }
+                Err(de::Error::missing_field("subjects"))
+            }
+        }
+
+        const FIELDS: &[&str] = &["subject", "subjects"];
+        deserializer.deserialize_struct("Record", FIELDS, RecordVisitor)
+    }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -276,7 +276,7 @@ async fn app() {
 
         let user_name = "testuser".parse().unwrap();
         let user_record = UserRecord {
-            subject: SUBJECT.into(),
+            subjects: vec![SUBJECT.into()],
         };
 
         let anon_user = anon_cl.user(&user_name);
@@ -299,7 +299,7 @@ async fn app() {
         }
         assert!(oidc_user
             .create(&UserRecord {
-                subject: format!("{}other", user_record.subject),
+                subjects: vec![format!("{}other", user_record.subjects[0])],
             })
             .is_err());
         assert!(oidc_user


### PR DESCRIPTION
Follow-up to #306, which adds support for listing multiple users as subjects on a UserRecord, enabling all of them to manage repositories/tags under that user.

This does not break HTTP API compatibility: it still reads the User Record with a singular subject.