### PR TITLE
feat: check access token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -446,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,12 +561,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -568,9 +598,13 @@ dependencies = [
  "drawbridge-type",
  "futures",
  "http-types",
+ "jsonwebtoken",
  "openidconnect",
+ "rand 0.8.5",
+ "rsa",
  "rustls",
  "rustls-pemfile",
+ "serde",
  "serde_json",
  "tempfile",
  "tracing",
@@ -627,6 +661,7 @@ dependencies = [
  "futures",
  "futures-rustls",
  "hyper",
+ "jsonwebtoken",
  "mime",
  "once_cell",
  "openidconnect",
@@ -1120,6 +1155,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
+dependencies = [
+ "base64",
+ "ring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,12 +1180,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
@@ -1250,6 +1306,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,12 +1333,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1346,6 +1431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1476,28 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "polling"
@@ -1571,6 +1687,27 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rsa"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ecc3307be66bfb3574577895555bacfb9a37a8d5cd959444b72ff02495c618"
+dependencies = [
+ "byteorder",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "smallvec",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1774,6 +1911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simple-mutex"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1959,22 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,13 @@ drawbridge-client = { path = "./crates/client" }
 async-h1 = { version = "2.3.3", default-features = false }
 async-std = { version = "1.11.0", default-features = false, features = ["attributes", "default"] }
 http-types = { version = "2.12.0", default-features = false }
+jsonwebtoken = { version = "8", default-features = false }
 openidconnect = { version = "2.4.0", default-features = false }
+rsa = "0.7"
+rand = "0.8"
 rustls = { version = "0.20.6", default-features = false }
 rustls-pemfile = { version = "1.0.0", default-features = false }
+serde = "1"
 serde_json = { version = "1.0.87", default-features = false, features = ["std"] }
 tempfile = { version = "3.3.0", default-features = false }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,6 +23,7 @@ cap-async-std = { version = "0.24.4", default-features = true, features = ["fs_u
 futures = { version = "0.3.21", default-features = false, features = ["async-await"] }
 futures-rustls = { version = "0.22.1", default-features = false }
 hyper = { version = "0.14.22", default-features = false, features = ["http1", "server"] }
+jsonwebtoken = { version = "8", default-features = false }
 tracing = { version = "0.1.37", default-features = false, features = ["release_max_level_debug"] }
 mime = { version = "0.3.16", default-features = false }
 once_cell = { version = "1.16.0", default-features = false }

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -5,6 +5,8 @@ mod oidc;
 mod tls;
 
 pub use oidc::Claims as OidcClaims;
+pub use oidc::Verifier as OidcVerifier;
+pub use oidc::{ScopeContext, ScopeLevel};
 pub use tls::{Config as TlsConfig, TrustedCertificate};
 
 use super::{Repository, Store, User};
@@ -32,7 +34,7 @@ pub async fn assert_repository_read<'a>(
         RequestParts::new(req)
             .extract::<OidcClaims>()
             .await?
-            .assert_user(store, &cx.owner)
+            .assert_user(store, &cx.owner, ScopeContext::Repository, ScopeLevel::Read)
             .await
             .map_err(IntoResponse::into_response)
             .map(|user| (repo, Some(user)))

--- a/crates/server/src/auth/oidc.rs
+++ b/crates/server/src/auth/oidc.rs
@@ -1,14 +1,16 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::store::GetError;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use super::super::{Store, User};
+use crate::{store::GetError, OidcConfig, Store, User};
 
 use drawbridge_type::{UserContext, UserRecord};
 
-use std::ops::Deref;
-
+use anyhow::{anyhow, bail, Context};
 use axum::extract::rejection::{TypedHeaderRejection, TypedHeaderRejectionReason};
 use axum::extract::{Extension, FromRequest, RequestParts};
 use axum::headers::authorization::Bearer;
@@ -16,31 +18,188 @@ use axum::headers::Authorization;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::{async_trait, TypedHeader};
-use openidconnect::core::{CoreClient, CoreUserInfoClaims};
+use jsonwebtoken::{
+    decode, decode_header,
+    jwk::{AlgorithmParameters, JwkSet},
+    Algorithm, DecodingKey, Validation,
+};
+use openidconnect::core::CoreProviderMetadata;
 use openidconnect::ureq::http_client;
-use openidconnect::AccessToken;
-use tracing::{debug, error, trace, warn};
+use openidconnect::IssuerUrl;
+use serde::{Deserialize, Deserializer};
+use tracing::{error, info, trace, warn};
 
-#[repr(transparent)]
-#[derive(Clone, Debug)]
-pub struct Claims(CoreUserInfoClaims);
+pub struct Verifier {
+    keyset: HashMap<String, DecodingKey>,
+    validator: Validation,
+}
 
-impl Deref for Claims {
-    type Target = CoreUserInfoClaims;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl std::fmt::Debug for Verifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Verifier")
+            .field("validator", &self.validator)
+            .finish()
     }
 }
 
+#[derive(Clone, Debug, Deserialize)]
+struct VerifiedInfo {
+    #[serde(rename = "sub")]
+    subject: String,
+    #[serde(rename = "scope", deserialize_with = "deserialize_scopes")]
+    scopes: HashSet<String>,
+}
+
+#[allow(single_use_lifetimes)]
+fn deserialize_scopes<'de, D>(deserializer: D) -> Result<HashSet<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    Ok(HashSet::from_iter(s.split(' ').map(|s| s.to_owned())))
+}
+
+impl Verifier {
+    pub fn new(config: OidcConfig) -> Result<Self, anyhow::Error> {
+        let mut validator = Validation::new(Algorithm::RS256);
+        validator.set_audience(&[config.audience]);
+        validator.set_issuer(&[config.issuer.as_str()]);
+        validator.set_required_spec_claims(&["exp", "iat", "scope", "aud"]);
+        validator.validate_exp = true;
+
+        let oidc_md =
+            CoreProviderMetadata::discover(&IssuerUrl::from_url(config.issuer), http_client)
+                .context("failed to discover provider metadata")?;
+        let jwks = oidc_md.jwks();
+        let jwks = serde_json::to_string(&jwks).context("failed to serialize jwks")?;
+        let keyset: JwkSet = serde_json::from_str(&jwks).context("failed to parse jwks")?;
+        let keyset = keyset
+            .keys
+            .into_iter()
+            .map(|jwk| {
+                let kid = jwk.common.key_id.ok_or_else(|| anyhow!("missing kid"))?;
+                let key = match jwk.algorithm {
+                    AlgorithmParameters::RSA(ref rsa) => {
+                        DecodingKey::from_rsa_components(&rsa.n, &rsa.e)
+                            .context("Error creating DecodingKey")
+                    }
+                    _ => bail!("Unsupported algorithm encountered: {:?}", jwk.algorithm),
+                }?;
+                Ok((kid, key))
+            })
+            .collect::<Result<HashMap<String, DecodingKey>, anyhow::Error>>()
+            .context("failed to parse jwks")?;
+
+        Ok(Self { keyset, validator })
+    }
+
+    fn verify_token(&self, token: &str) -> Result<VerifiedInfo, anyhow::Error> {
+        let header = decode_header(token).context("Error decoding header")?;
+        let kid = match header.kid {
+            Some(k) => k,
+            None => bail!("Token doesn't have a `kid` header field"),
+        };
+        let key = self
+            .keyset
+            .get(&kid)
+            .ok_or_else(|| anyhow!("No key found for kid: {}", kid))?;
+        let decoded_token =
+            decode::<VerifiedInfo>(token, key, &self.validator).context("Error decoding token")?;
+        Ok(decoded_token.claims)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ScopeContext {
+    User,
+    Repository,
+    Tag,
+}
+
+impl std::fmt::Display for ScopeContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScopeContext::User => write!(f, "drawbridge_users"),
+            ScopeContext::Repository => write!(f, "drawbridge_repositories"),
+            ScopeContext::Tag => write!(f, "drawbridge_tags"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ScopeLevel {
+    Read,
+    Write,
+}
+
+impl std::fmt::Display for ScopeLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScopeLevel::Read => write!(f, "read"),
+            ScopeLevel::Write => write!(f, "write"),
+        }
+    }
+}
+
+impl ScopeLevel {
+    fn sufficient_levels(&self) -> &[&str] {
+        match self {
+            ScopeLevel::Read => &["read", "manage"],
+            ScopeLevel::Write => &["write", "manage"],
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct Claims(VerifiedInfo);
+
 impl Claims {
-    /// Assert that the client is the user identified by `cx`.
+    pub fn subject(&self) -> &str {
+        &self.0.subject
+    }
+
+    fn check_scope(
+        &self,
+        context: ScopeContext,
+        level: ScopeLevel,
+    ) -> Result<(), (StatusCode, String)> {
+        for level in level.sufficient_levels() {
+            let scope = format!("{}:{}", level, context);
+            if self.0.scopes.contains(&scope) {
+                return Ok(());
+            }
+        }
+        Err((
+            StatusCode::UNAUTHORIZED,
+            format!(
+                "Token is missing a scope for level {}, context {}",
+                level, context
+            ),
+        ))
+    }
+
+    /// Asserts that the token has a scope that satisfies the given context and level.
+    #[allow(clippy::result_large_err)]
+    pub fn assert_scope(
+        &self,
+        context: ScopeContext,
+        level: ScopeLevel,
+    ) -> Result<(), impl IntoResponse> {
+        self.check_scope(context, level)
+            .map_err(|e| e.into_response())
+    }
+
+    /// Assert that the client is the user identified by `cx`, and that the token has a scope that
+    /// satisfies the given context and level.
     pub async fn assert_user<'a>(
         &self,
         store: &'a Store,
         cx: &UserContext,
+        scope_context: ScopeContext,
+        scope_level: ScopeLevel,
     ) -> Result<User<'a>, impl IntoResponse> {
-        let subj = self.0.subject().as_str();
+        let subj = self.subject();
         let oidc_record = UserRecord {
             subject: subj.to_string(),
         };
@@ -64,6 +223,9 @@ e.into_response()
                 .into_response());
         }
 
+        self.check_scope(scope_context, scope_level)
+            .map_err(|e| e.into_response())?;
+
         Ok(user)
     }
 }
@@ -82,32 +244,26 @@ impl<B: Send> FromRequest<B> for Claims {
                     }
                     _ => e.into_response(),
                 })?;
-        let token = AccessToken::new(token.token().into());
+        warn!(target: "app::auth::oidc", ?token, "got token");
 
-        let Extension(oidc) = req.extract::<Extension<CoreClient>>().await.map_err(|e| {
-            error!(target: "app::auth::oidc", "OpenID Connect client extension missing");
-            e.into_response()
-        })?;
+        let Extension(verifier) = req
+            .extract::<Extension<Arc<Verifier>>>()
+            .await
+            .map_err(|e| {
+                error!(target: "app::auth::oidc", "OpenID Connect verifier extension missing");
+                e.into_response()
+            })?;
 
-        let info_req = oidc.user_info(token, None).map_err(|e| {
-            error!(target: "app::auth::oidc", "failed to construct user info request: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "OpenID Connect client initialization failed",
-            )
-                .into_response()
-        })?;
+        trace!(target: "app:auth::oidc", "verifying token");
 
-        trace!(target: "app:auth::oidc", "request user info");
-        let claims = info_req.request(http_client).map_err(|e| {
-            debug!(target: "app::auth::oidc", "failed to request user info: {e}");
-            (
-                StatusCode::UNAUTHORIZED,
-                format!("OpenID Connect credential validation failed: {e}"),
-            )
-                .into_response()
-        })?;
-        trace!(target: "app:auth::oidc", "received user claims: {:?}", claims);
-        Ok(Self(claims))
+        let claims = verifier
+            .verify_token(token.token())
+            .map_err(|e| {
+                error!(target: "app::auth::oidc", error = ?e, "failed to verify token");
+                (StatusCode::UNAUTHORIZED, "Invalid token provided").into_response()
+            })
+            .map(Self);
+        info!(target: "app::auth::oidc", ?claims, "verified token");
+        claims
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -38,7 +38,7 @@ pub mod tags;
 pub mod trees;
 pub mod users;
 
-pub use auth::{OidcClaims, TlsConfig, TrustedCertificate};
+pub use auth::{OidcClaims, ScopeContext, ScopeLevel, TlsConfig, TrustedCertificate};
 pub use builder::*;
 pub(crate) use handle::*;
 pub(crate) use store::*;

--- a/crates/server/src/repos/get.rs
+++ b/crates/server/src/repos/get.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::RepositoryContext;
 
@@ -18,7 +18,7 @@ pub async fn get(
     trace!(target: "app::trees::get", "called for `{cx}`");
 
     let user = claims
-        .assert_user(store, &cx.owner)
+        .assert_user(store, &cx.owner, ScopeContext::Repository, ScopeLevel::Read)
         .await
         .map_err(IntoResponse::into_response)?;
 

--- a/crates/server/src/repos/head.rs
+++ b/crates/server/src/repos/head.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::RepositoryContext;
 
@@ -18,7 +18,7 @@ pub async fn head(
     trace!(target: "app::trees::head", "called for `{cx}`");
 
     claims
-        .assert_user(store, &cx.owner)
+        .assert_user(store, &cx.owner, ScopeContext::Repository, ScopeLevel::Read)
         .await
         .map_err(IntoResponse::into_response)?
         .repository(&cx.name)

--- a/crates/server/src/repos/put.rs
+++ b/crates/server/src/repos/put.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::{Meta, RepositoryConfig, RepositoryContext};
 
@@ -21,7 +21,12 @@ pub async fn put(
     trace!(target: "app::trees::put", "called for `{cx}`");
 
     claims
-        .assert_user(store, &cx.owner)
+        .assert_user(
+            store,
+            &cx.owner,
+            ScopeContext::Repository,
+            ScopeLevel::Write,
+        )
         .await
         .map_err(IntoResponse::into_response)?
         .create_repository(&cx.name, meta, &config)

--- a/crates/server/src/tags/put.rs
+++ b/crates/server/src/tags/put.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_jose::jws::Jws;
 use drawbridge_jose::MediaTyped;
@@ -33,7 +33,12 @@ pub async fn put(
     }
 
     let user = claims
-        .assert_user(&store, &cx.repository.owner)
+        .assert_user(
+            &store,
+            &cx.repository.owner,
+            ScopeContext::Tag,
+            ScopeLevel::Write,
+        )
         .await
         .map_err(IntoResponse::into_response)?;
 

--- a/crates/server/src/trees/put.rs
+++ b/crates/server/src/trees/put.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::{Meta, TreeContext, TreeDirectory};
 
@@ -32,7 +32,12 @@ pub async fn put(
     }
 
     let user = claims
-        .assert_user(store, &cx.tag.repository.owner)
+        .assert_user(
+            store,
+            &cx.tag.repository.owner,
+            ScopeContext::Tag,
+            ScopeLevel::Write,
+        )
         .await
         .map_err(IntoResponse::into_response)?;
 

--- a/crates/server/src/users/get.rs
+++ b/crates/server/src/users/get.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::UserContext;
 
@@ -18,7 +18,7 @@ pub async fn get(
     trace!(target: "app::users::get", "called for `{cx}`");
 
     let user = claims
-        .assert_user(store, cx)
+        .assert_user(store, cx, ScopeContext::User, ScopeLevel::Read)
         .await
         .map_err(IntoResponse::into_response)?;
 

--- a/crates/server/src/users/head.rs
+++ b/crates/server/src/users/head.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::UserContext;
 
@@ -18,7 +18,7 @@ pub async fn head(
     trace!(target: "app::users::head", "called for `{cx}`");
 
     claims
-        .assert_user(store, cx)
+        .assert_user(store, cx, ScopeContext::User, ScopeLevel::Read)
         .await
         .map_err(IntoResponse::into_response)?
         .get_meta()

--- a/crates/server/src/users/put.rs
+++ b/crates/server/src/users/put.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::super::{OidcClaims, Store};
+use super::super::{OidcClaims, ScopeContext, ScopeLevel, Store};
 
 use drawbridge_type::{Meta, UserContext, UserRecord};
 
@@ -20,7 +20,11 @@ pub async fn put(
 ) -> impl IntoResponse {
     trace!(target: "app::users::put", "called for `{cx}`");
 
-    if record.subject != claims.subject().as_str() {
+    claims
+        .assert_scope(ScopeContext::User, ScopeLevel::Write)
+        .map_err(IntoResponse::into_response)?;
+
+    if record.subject != claims.subject() {
         return Err((StatusCode::UNAUTHORIZED, "OpenID Connect subject mismatch").into_response());
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           extendDerivations {
             buildInputs = [
               pkgs.openssl
+              pkgs.pkg-config
             ];
           }
           devShells;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+
 use drawbridge_client::mime::APPLICATION_OCTET_STREAM;
 use drawbridge_client::types::{RepositoryConfig, TreePath, UserRecord};
 use drawbridge_client::Client;
@@ -15,17 +20,32 @@ use futures::channel::oneshot::channel;
 use futures::{join, try_join, StreamExt};
 use http_types::convert::{json, Serialize};
 use http_types::{Body, Response, StatusCode};
+use jsonwebtoken::{encode, EncodingKey, Header};
 use openidconnect::core::{
-    CoreJsonWebKey, CoreJsonWebKeySet, CoreJwsSigningAlgorithm, CoreProviderMetadata,
-    CoreResponseType, CoreSubjectIdentifierType, CoreUserInfoClaims,
+    CoreJwsSigningAlgorithm, CoreProviderMetadata, CoreResponseType, CoreSubjectIdentifierType,
 };
 use openidconnect::{
-    AuthUrl, EmptyAdditionalClaims, EmptyAdditionalProviderMetadata, IssuerUrl, JsonWebKeySetUrl,
-    ResponseTypes, StandardClaims, SubjectIdentifier, UserInfoUrl,
+    AuthUrl, EmptyAdditionalProviderMetadata, IssuerUrl, JsonWebKeySetUrl, ResponseTypes,
 };
+use rsa::{pkcs1::EncodeRsaPrivateKey, PublicKeyParts};
 use rustls::{Certificate, PrivateKey, RootCertStore};
 use rustls_pemfile::Item::*;
 use tempfile::tempdir;
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct TokenClaims {
+    #[serde(rename = "iss")]
+    issuer: String,
+    #[serde(rename = "aud")]
+    audience: Vec<String>,
+    #[serde(rename = "sub")]
+    subject: String,
+    #[serde(rename = "iat")]
+    issued_at: u64,
+    #[serde(rename = "exp")]
+    expires_at: u64,
+    scope: String,
+}
 
 #[async_std::test]
 async fn app() {
@@ -35,9 +55,99 @@ async fn app() {
         .await
         .expect("failed to bind to address");
     let oidc_addr = oidc_lis.local_addr().unwrap();
+    let oidc_issuer = format!("http://{}/", oidc_addr);
+    let oidc_audience = "testserver";
 
-    const TOKEN: &str = "test-token";
+    let mut rng = rand::thread_rng();
+    let oidc_key_raw = rsa::RsaPrivateKey::new(&mut rng, 2048).expect("failed to generate a key");
+    let oidc_key_der = oidc_key_raw.to_pkcs1_der().expect("failed to encode key");
+    let oidc_key = EncodingKey::from_rsa_der(&oidc_key_der.as_bytes());
+    let oidc_key_pub = oidc_key_raw.to_public_key();
+    let oidc_key_jwk = drawbridge_jose::jwk::Jwk {
+        key: drawbridge_jose::jwk::Key::Rsa {
+            prv: None,
+            n: oidc_key_pub.n().to_bytes_be().into(),
+            e: oidc_key_pub.e().to_bytes_be().into(),
+        },
+        prm: drawbridge_jose::jwk::Parameters {
+            kid: Some("signkey".into()),
+            ..Default::default()
+        },
+    };
+    let oidc_pubkeys = drawbridge_jose::jwk::JwkSet {
+        keys: vec![oidc_key_jwk.clone()],
+    };
+
     const SUBJECT: &str = "test|subject";
+
+    let mut jwt_header = Header::new(jsonwebtoken::Algorithm::RS256);
+    jwt_header.kid = Some("signkey".to_owned());
+    let jwt_payload = TokenClaims {
+        issuer: oidc_issuer.clone(),
+        audience: vec![oidc_audience.to_owned()],
+        subject: SUBJECT.to_owned(),
+        issued_at: SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        expires_at: (SystemTime::now() + Duration::from_secs(3600))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        scope:
+            "openid manage:drawbridge_users manage:drawbridge_repositories manage:drawbridge_tags"
+                .into(),
+    };
+
+    let mut oidc_tokens = HashMap::from([
+        ("valid", {
+            let payload = jwt_payload.clone();
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("expired", {
+            let mut payload = jwt_payload.clone();
+            payload.issued_at = SystemTime::now()
+                .checked_sub(Duration::from_secs(3600))
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            payload.expires_at = SystemTime::now()
+                .checked_sub(Duration::from_secs(3600))
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("no_scopes", {
+            let mut payload = jwt_payload.clone();
+            payload.scope = "openid".into();
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("missing_manage_user_scope", {
+            let mut payload = jwt_payload.clone();
+            payload.scope = "openid manage:drawbridge_repositories manage:drawbridge_tags read:drawbridge_users".into();
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("invalid_aud", {
+            let mut payload = jwt_payload.clone();
+            payload.audience = vec!["invalid".into()];
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("invalid_iss", {
+            let mut payload = jwt_payload.clone();
+            payload.issuer = "invalid".into();
+            encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token")
+        }),
+        ("invalid_sig", {
+            let payload = jwt_payload.clone();
+            let mut token = encode(&jwt_header, &payload, &oidc_key).expect("failed to sign token");
+            token.pop();
+            token
+        }),
+    ]);
+    let oidc_token_valid = oidc_tokens.remove("valid").unwrap();
 
     let (oidc_tx, oidc_rx) = channel::<()>();
     let oidc = spawn(async move {
@@ -45,6 +155,8 @@ async fn app() {
             .incoming()
             .take_until(oidc_rx)
             .for_each_concurrent(None, |stream| async {
+                let oidc_pubkeys = &oidc_pubkeys;
+
                 async_h1::accept(
                     stream.expect("failed to initialize stream"),
                     |req| async move {
@@ -60,8 +172,8 @@ async fn app() {
 
                         let oidc_url = format!("http://{oidc_addr}/");
                         match req.url().path() {
-                            "/.well-known/openid-configuration" => json_response(
-                                &CoreProviderMetadata::new(
+                            "/.well-known/openid-configuration" => {
+                                json_response(&CoreProviderMetadata::new(
                                     // Parameters required by the OpenID Connect Discovery spec.
                                     IssuerUrl::new(oidc_url.to_string()).unwrap(),
                                     AuthUrl::new(format!("{oidc_url}authorize")).unwrap(),
@@ -71,24 +183,9 @@ async fn app() {
                                     vec![CoreSubjectIdentifierType::Pairwise],
                                     vec![CoreJwsSigningAlgorithm::RsaSsaPssSha256],
                                     EmptyAdditionalProviderMetadata {},
-                                )
-                                .set_userinfo_endpoint(Some(
-                                    UserInfoUrl::new(format!("{oidc_url}userinfo")).unwrap(),
-                                )),
-                            ),
-                            "/jwks" => json_response(&CoreJsonWebKeySet::new(vec![
-                                CoreJsonWebKey::new_rsa(b"ntest".to_vec(), b"etest".to_vec(), None),
-                            ])),
-                            "/userinfo" => {
-                                let auth = req
-                                    .header("Authorization")
-                                    .expect("Authorization header missing");
-                                assert_eq!(auth.as_str().split_once(' '), Some(("Bearer", TOKEN)),);
-                                json_response(&CoreUserInfoClaims::new(
-                                    StandardClaims::new(SubjectIdentifier::new(SUBJECT.into())),
-                                    EmptyAdditionalClaims {},
                                 ))
                             }
+                            "/jwks" => json_response(&oidc_pubkeys),
                             p => panic!("Unsupported path requested: `{p}`"),
                         }
                     },
@@ -118,10 +215,8 @@ async fn app() {
             store.path(),
             tls,
             OidcConfig {
-                label: "test-label".into(),
-                issuer: format!("http://{oidc_addr}").parse().unwrap(),
-                client_id: "test-client_id".into(),
-                client_secret: None,
+                audience: oidc_audience.to_string(),
+                issuer: oidc_issuer.parse().unwrap(),
             },
         )
         .await
@@ -138,7 +233,7 @@ async fn app() {
     });
 
     let cl = spawn_blocking(move || async move {
-        let (anon_cl, cert_cl, oidc_cl) = {
+        let (anon_cl, cert_cl, oidc_valid_cl, blank_cl) = {
             let cl = Client::builder(format!("https://localhost:{srv_port}").parse().unwrap())
                 .roots({
                     let mut roots = RootCertStore::empty();
@@ -174,7 +269,8 @@ async fn app() {
             (
                 cl.clone().build().unwrap(),
                 cl.clone().credentials(cert, key).build().unwrap(),
-                cl.token(TOKEN).build().unwrap(),
+                cl.clone().token(oidc_token_valid).build().unwrap(),
+                cl,
             )
         };
 
@@ -185,7 +281,7 @@ async fn app() {
 
         let anon_user = anon_cl.user(&user_name);
         let cert_user = cert_cl.user(&user_name);
-        let oidc_user = oidc_cl.user(&user_name);
+        let oidc_user = oidc_valid_cl.user(&user_name);
 
         assert!(anon_user.get().is_err());
         assert!(cert_user.get().is_err());
@@ -193,6 +289,14 @@ async fn app() {
 
         assert!(anon_user.create(&user_record).is_err());
         assert!(cert_user.create(&user_record).is_err());
+        for (token_type, token) in oidc_tokens {
+            let client = blank_cl.clone().token(token).build().unwrap();
+            assert!(
+                client.user(&user_name).create(&user_record).is_err(),
+                "OIDC token type {} accepted incorrectly",
+                token_type
+            );
+        }
         assert!(oidc_user
             .create(&UserRecord {
                 subject: format!("{}other", user_record.subject),
@@ -201,7 +305,7 @@ async fn app() {
         assert!(oidc_user
             .create(&user_record)
             .expect("failed to create user"));
-        assert!(oidc_cl
+        assert!(oidc_valid_cl
             .user(&format!("{user_name}other").parse().unwrap())
             .create(&user_record)
             .expect("failed to create other user"));


### PR DESCRIPTION
Change verification of Access Token to actually verify JWT signatures and audience/scope claims.
This prevents tokens issued for one service or environment to be used here, and for tokens acquired for limited permissions to be used for others.

It also means no network requests need to be performed during verification of requests.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>