### PR TITLE
fix: remove limit of 1 active connection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ async fn main() -> anyhow::Result<()> {
         .await
         .with_context(|| format!("Failed to bind to {}", addr))?
         .incoming()
-        .for_each_concurrent(Some(1), |stream| async {
+        .for_each_concurrent(None, |stream| async {
             if let Err(e) = async {
                 let stream = stream.context("failed to initialize connection")?;
                 debug!(


### PR DESCRIPTION
This was put in place during the move to async-std, and limits the number of active connections to 1.

Fixes: d445a946
Signed-off-by: Patrick Uiterwijk <patrick@profian.com>