### PR TITLE
chore: update some dependences, fix some clippy errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,35 +335,34 @@ checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 
 [[package]]
 name = "cap-async-std"
-version = "0.24.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c2fabb6b63843ea4839a27bbfb2e6a33eff8ed6337651975d11d3d43b605b4"
+checksum = "13360e63b8c0114c94320023cb56b21d691a1158382e473655e5d2388a033257"
 dependencies = [
  "async-std",
  "camino",
  "cap-primitives",
  "io-extras",
- "io-lifetimes 0.5.3",
+ "io-lifetimes",
  "ipnet",
- "rustix 0.33.7",
+ "rustix",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "0.24.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8fca3e81fae1d91a36e9784ca22a39ef623702b5f7904d89dc31f10184a178"
+checksum = "af3f336aa91cce16033ed3c94ac91d98956c49b420e6d6cd0dd7d0e386a57085"
 dependencies = [
  "ambient-authority",
- "errno",
  "fs-set-times",
  "io-extras",
- "io-lifetimes 0.5.3",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.33.7",
- "winapi",
+ "rustix",
  "winapi-util",
+ "windows-sys 0.36.1",
  "winx",
 ]
 
@@ -458,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -596,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -606,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -648,7 +647,7 @@ dependencies = [
 name = "drawbridge-byte"
 version = "0.4.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "serde",
 ]
 
@@ -717,7 +716,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "drawbridge-byte",
  "drawbridge-jose",
  "futures",
@@ -800,20 +799,20 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
+checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
 dependencies = [
- "io-lifetimes 0.5.3",
- "rustix 0.33.7",
- "winapi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -825,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -835,15 +834,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -862,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -884,21 +883,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1129,22 +1128,13 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
+checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
 dependencies = [
  "async-std",
- "io-lifetimes 0.5.3",
- "winapi",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
-dependencies = [
- "async-std",
+ "io-lifetimes",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1152,6 +1142,9 @@ name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+dependencies = [
+ "async-std",
+]
 
 [[package]]
 name = "ipnet"
@@ -1233,12 +1226,6 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1342,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -1720,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
+checksum = "89b3896c9b7790b70a9aa314a30e4ae114200992a19c96cbe0ca6070edd32ab8"
 dependencies = [
  "byteorder",
  "digest",
@@ -1734,25 +1721,8 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "signature",
- "smallvec",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustix"
-version = "0.33.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.5.3",
- "itoa",
- "libc",
- "linux-raw-sys 0.0.42",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -1763,9 +1733,11 @@ checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.7.5",
+ "io-lifetimes",
+ "itoa",
  "libc",
- "linux-raw-sys 0.0.46",
+ "linux-raw-sys",
+ "once_cell",
  "windows-sys 0.42.0",
 ]
 
@@ -1986,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
@@ -2102,7 +2074,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
 dependencies = [
- "rustix 0.35.13",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -2680,13 +2652,13 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winx"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
+checksum = "b7b01e010390eb263a4518c8cebf86cb67469d1511c00b749a47b64c39e8054d"
 dependencies = [
  "bitflags",
- "io-lifetimes 0.5.3",
- "winapi",
+ "io-lifetimes",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ anyhow = { version = "1.0.68", default-features = false }
 async-h1 = { version = "2.3.3", default-features = false }
 async-std = { version = "1.11.0", default-features = false }
 axum = { version = "0.5.17", default-features = false }
-base64 = { version = "0.13.1", default-features = false }
+base64 = { version = "0.21.0", default-features = false }
 camino = { version = "1.1.2", default-features = false }
-cap-async-std = { version = "0.24.4", default-features = true, features = ["fs_utf8"] }
+cap-async-std = { version = "0.26.1", default-features = true, features = ["fs_utf8"] }
 clap = { version = "4.1.4", default-features = false, features = ["derive", "error-context", "help", "std", "usage", "wrap_help"] }
 confargs = { version = "0.1.3", default-features = false }
-futures = { version = "0.3.21", default-features = false }
+futures = { version = "0.3.26", default-features = false }
 futures-rustls = { version = "0.22.1", default-features = false }
 headers = { version = "0.3.7", default-features = false }
 http = { version = "0.2.6", default-features = false }
@@ -48,7 +48,7 @@ mime = { version = "0.3.16", default-features = false }
 once_cell = { version = "1.17.0", default-features = false }
 openidconnect = { version = "2.5.0", default-features = false }
 rand = { version = "0.8.5", default-features = false }
-rsa = { version = "0.7.2", default-features = false }
+rsa = { version = "0.8.1", default-features = false }
 rustls = { version = "0.20.8", default-features = false }
 rustls-pemfile = { version = "1.0.2", default-features = false }
 semver = { version = "1.0.16", default-features = false }

--- a/crates/server/src/auth/oidc.rs
+++ b/crates/server/src/auth/oidc.rs
@@ -160,17 +160,14 @@ impl Claims {
         level: ScopeLevel,
     ) -> Result<(), (StatusCode, String)> {
         for level in level.sufficient_levels() {
-            let scope = format!("{}:{}", level, context);
+            let scope = format!("{level}:{context}");
             if self.0.scopes.contains(&scope) {
                 return Ok(());
             }
         }
         Err((
             StatusCode::UNAUTHORIZED,
-            format!(
-                "Token is missing a scope for level {}, context {}",
-                level, context
-            ),
+            format!("Token is missing a scope for level {level}, context {context}"),
         ))
     }
 

--- a/crates/server/src/builder.rs
+++ b/crates/server/src/builder.rs
@@ -5,12 +5,12 @@ use super::{handle, App, Store, TlsConfig};
 
 use anyhow::{anyhow, Context};
 use async_std::fs::File;
+use async_std::path::Path;
 use async_std::sync::Arc;
 use axum::handler::Handler;
 use axum::routing::any;
 use axum::{Extension, Router};
 use cap_async_std::fs_utf8::Dir;
-use cap_async_std::path::Path;
 use futures::lock::Mutex;
 use futures::TryFutureExt;
 use futures_rustls::TlsAcceptor;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -46,10 +46,10 @@ pub(crate) use store::*;
 pub use openidconnect::url;
 
 use anyhow::Context as _;
+use async_std::path::Path;
 use axum::extract::Extension;
 use axum::routing::IntoMakeService;
 use axum::Router;
-use cap_async_std::path::Path;
 use futures::lock::Mutex;
 use futures::{AsyncRead, AsyncWrite};
 use futures_rustls::TlsAcceptor;

--- a/crates/server/src/store/entity.rs
+++ b/crates/server/src/store/entity.rs
@@ -39,10 +39,7 @@ impl<E> IntoResponse for CreateError<E> {
             }
             CreateError::LengthMismatch { expected, got } => (
                 StatusCode::BAD_REQUEST,
-                format!(
-                    "Content length mismatch, expected: {}, got {}",
-                    expected, got
-                ),
+                format!("Content length mismatch, expected: {expected}, got {got}"),
             )
                 .into_response(),
             CreateError::Internal(_) => STORAGE_FAILURE_RESPONSE.into_response(),

--- a/crates/type/src/digest/digests.rs
+++ b/crates/type/src/digest/digests.rs
@@ -102,7 +102,7 @@ where
         let mut comma = "";
 
         for (algo, hash) in self.iter() {
-            write!(f, "{}{}=:{}:", comma, algo, hash)?;
+            write!(f, "{comma}{algo}=:{hash}:")?;
             comma = ",";
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
     .context("Failed to build app")?;
     TcpListener::bind(addr)
         .await
-        .with_context(|| format!("Failed to bind to {}", addr))?
+        .with_context(|| format!("Failed to bind to {addr}"))?
         .incoming()
         .for_each_concurrent(None, |stream| async {
             if let Err(e) = async {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -53,7 +53,7 @@ async fn app() {
         .await
         .expect("failed to bind to address");
     let oidc_addr = oidc_lis.local_addr().unwrap();
-    let oidc_issuer = format!("http://{}/", oidc_addr);
+    let oidc_issuer = format!("http://{oidc_addr}/");
     let oidc_audience = "testserver";
 
     let mut rng = rand::thread_rng();
@@ -260,7 +260,7 @@ async fn app() {
             .unwrap()
             .map(|item| match item {
                 RSAKey(buf) | PKCS8Key(buf) | ECKey(buf) => PrivateKey(buf),
-                _ => panic!("unsupported key type `{:?}`", item),
+                _ => panic!("unsupported key type `{item:?}`"),
             })
             .unwrap();
 
@@ -291,8 +291,7 @@ async fn app() {
             let client = blank_cl.clone().token(token).build().unwrap();
             assert!(
                 client.user(&user_name).create(&user_record).is_err(),
-                "OIDC token type {} accepted incorrectly",
-                token_type
+                "OIDC token type {token_type} accepted incorrectly"
             );
         }
         assert!(oidc_user


### PR DESCRIPTION
Some errors in the output which somehow still allowed the unit test to pass successfully, not sure if intentional or not.

```
     Running tests/mod.rs (target/debug/deps/mod-839111660b709219)

running 1 test
test app ... 2023-02-01T03:28:29.146903Z ERROR app::auth::oidc: failed to verify token error=Error decoding token

Caused by:
    ExpiredSignature
2023-02-01T03:28:29.151279Z ERROR app::auth::oidc: failed to verify token error=Error decoding token

Caused by:
    InvalidAudience
2023-02-01T03:28:29.159868Z ERROR app::auth::oidc: failed to verify token error=Error decoding token

Caused by:
    InvalidIssuer
2023-02-01T03:28:29.163667Z ERROR app::auth::oidc: failed to verify token error=Error decoding token

Caused by:
    Base64 error: Encoded text cannot have a 6-bit remainder.
ok
```

The Base64 error occurred after I updated the dependency, but the others were before I touched anything.