### PR TITLE
fix: address a possible bad clippy warning (where clippy is wrong)

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -27,6 +27,7 @@
     unused_results,
     variant_size_differences
 )]
+#![allow(clippy::almost_swapped)] // https://github.com/profianinc/drawbridge/issues/423
 
 mod builder;
 mod handle;


### PR DESCRIPTION
Ref https://github.com/profianinc/drawbridge/issues/423