### PR TITLE
fix: clippy issue resolved

### DIFF
--- a/crates/server/src/builder.rs
+++ b/crates/server/src/builder.rs
@@ -95,7 +95,7 @@ impl<S: AsRef<Path>> Builder<S> {
                     .layer(Extension(Arc::new(oidc_verifier)))
                     .layer(
                         TraceLayer::new_for_http()
-                            .make_span_with(SpanMaker::default())
+                            .make_span_with(SpanMaker)
                             .on_request(DefaultOnRequest::new().level(Level::INFO))
                             .on_response(
                                 DefaultOnResponse::new()


### PR DESCRIPTION
It seems that Rust 1.71 introduced a new pattern for Clippy where a struct that derives `Default` can just use `StructName` instead of `StructName::default()`.

Related to https://github.com/profianinc/steward/pull/276